### PR TITLE
Add interactive routes via gesture recognizer registering

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 		9B3F057DF17503290A41DCEEB00EDEA1 /* Container.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E2737208CA49F7F536058C3CCDC4C7 /* Container.swift */; };
 		9B4D50598B013F7CCD60829FCB8AF200 /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB990D30757E2E7A8F5266831BBBE5F /* NavigationCoordinator.swift */; };
 		9B778AAD0E88F3BDDD602B2B2FEC1B1D /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F02770C75E2267F84754C8BFD54C12 /* Queue.swift */; };
+		9B82682221C9D7FA005841A8 /* GestureRecognizerTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B82682121C9D7FA005841A8 /* GestureRecognizerTarget.swift */; };
 		9BA39706EC9DD21CE53AC3761F75FB31 /* NopDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21BC7DE0DE3A526433A989439B529BB /* NopDisposable.swift */; };
 		9BD7B27321BB4296002B5FCD /* RedirectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD7B27221BB4295002B5FCD /* RedirectionCoordinator.swift */; };
 		9D60DF82508B477A3C1481AC69B0E23A /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F24821A7152CF96B2BD1496FB03F22 /* UIViewController+Rx.swift */; };
@@ -708,6 +709,7 @@
 		966520DD39779BD6DFB7BB679CF85DB5 /* ViewTransition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ViewTransition.swift; path = XCoordinator/Classes/ViewTransition.swift; sourceTree = "<group>"; };
 		9B2A479B21C452490097155E /* UIPageViewController+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIPageViewController+Configuration.swift"; path = "XCoordinator/Classes/UIPageViewController+Configuration.swift"; sourceTree = "<group>"; };
 		9B2A479D21C458660097155E /* PageCoordinatorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PageCoordinatorDataSource.swift; path = XCoordinator/Classes/PageCoordinatorDataSource.swift; sourceTree = "<group>"; };
+		9B82682121C9D7FA005841A8 /* GestureRecognizerTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GestureRecognizerTarget.swift; path = XCoordinator/Classes/GestureRecognizerTarget.swift; sourceTree = "<group>"; };
 		9BD7B27221BB4295002B5FCD /* RedirectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RedirectionCoordinator.swift; path = XCoordinator/Classes/RedirectionCoordinator.swift; sourceTree = "<group>"; };
 		9C930BC1E5B36E06737CDF60A6A97A3F /* String+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Rx.swift"; path = "RxSwift/Extensions/String+Rx.swift"; sourceTree = "<group>"; };
 		9CA54932B21A4C168FA65DDF5BA2D1AE /* _RXKVOObserver.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = _RXKVOObserver.m; path = RxCocoa/Runtime/_RXKVOObserver.m; sourceTree = "<group>"; };
@@ -1276,6 +1278,7 @@
 				DF0FD0BD7C92DE9FAE87698FE6515DBE /* AnyRouter.swift */,
 				0F76B4AC324697CF1EA0750B2485D36D /* AnyTransitionPerformer.swift */,
 				1B41612009FADF1E63181F9DCA51E65C /* BaseCoordinator.swift */,
+				9B82682121C9D7FA005841A8 /* GestureRecognizerTarget.swift */,
 				FA4E151E152312608FB073C99D4DC83C /* BasicCoordinator.swift */,
 				33E2737208CA49F7F536058C3CCDC4C7 /* Container.swift */,
 				856E51D7536500C3CB19167954EC5AEE /* Coordinator.swift */,
@@ -2031,6 +2034,7 @@
 				7341E0B1C1A9794BBDA97FC5BB742AFE /* UIView+Store.swift in Sources */,
 				7468496FB975F6A67F9B67C059DEF613 /* ViewCoordinator.swift in Sources */,
 				1010D392DE54C44619778C97E66B9448 /* ViewTransition.swift in Sources */,
+				9B82682221C9D7FA005841A8 /* GestureRecognizerTarget.swift in Sources */,
 				FA599E8C5A5D9CB5C137B20B36342BA8 /* XCoordinator-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/XCoordinator/Coordinators/UserCoordinator.swift
+++ b/Example/XCoordinator/Coordinators/UserCoordinator.swift
@@ -22,7 +22,6 @@ class UserCoordinator: NavigationCoordinator<UserRoute> {
 
     init(user: String) {
         super.init(initialRoute: .user(user))
-        addPushGestureRecognizer()
     }
 
     // MARK: - Overrides
@@ -47,25 +46,31 @@ class UserCoordinator: NavigationCoordinator<UserRoute> {
         }
     }
 
+    // MARK: - Overrides
+
+    override func presented(from presentable: Presentable?) {
+        super.presented(from: presentable)
+        addPushGestureRecognizer(to: rootViewController)
+    }
+
     // MARK: - Methods
 
-    private func addPushGestureRecognizer() {
+    private func addPushGestureRecognizer(to container: Container) {
+        let view = container.view
         let gestureRecognizer = UIScreenEdgePanGestureRecognizer()
         gestureRecognizer.edges = .right
-
-        let topView = (rootViewController.topViewController ?? rootViewController)?.view
-        topView?.addGestureRecognizer(gestureRecognizer)
+        view?.addGestureRecognizer(gestureRecognizer)
 
         registerInteractiveTransition(
             for: .randomColor,
             triggeredBy: gestureRecognizer,
-            progress: { [weak topView] recognizer in
-                let xTranslation = -recognizer.translation(in: topView).x
+            progress: { [weak view] recognizer in
+                let xTranslation = -recognizer.translation(in: view).x
                 return max(min(xTranslation / UIScreen.main.bounds.width, 1), 0)
             },
-            shouldFinish: { [weak topView] recognizer in
-                let xTranslation = -recognizer.translation(in: topView).x
-                let xVelocity = -recognizer.velocity(in: topView).x
+            shouldFinish: { [weak view] recognizer in
+                let xTranslation = -recognizer.translation(in: view).x
+                let xVelocity = -recognizer.velocity(in: view).x
                 return xTranslation >= UIScreen.main.bounds.width / 2
                     || xVelocity >= UIScreen.main.bounds.width / 2
             },

--- a/Example/XCoordinator/Coordinators/UserCoordinator.swift
+++ b/Example/XCoordinator/Coordinators/UserCoordinator.swift
@@ -13,7 +13,7 @@ enum UserRoute: Route {
     case user(String)
     case alert(title: String, message: String)
     case users
-    case emptyForAnimation
+    case randomColor
 }
 
 class UserCoordinator: NavigationCoordinator<UserRoute> {
@@ -29,12 +29,9 @@ class UserCoordinator: NavigationCoordinator<UserRoute> {
 
     override func prepareTransition(for route: UserRoute) -> NavigationTransition {
         switch route {
-        case .emptyForAnimation:
+        case .randomColor:
             let viewController = UIViewController()
-
-            viewController.loadViewIfNeeded()
-            viewController.view.backgroundColor = .red
-
+            viewController.view.backgroundColor = .random()
             return .push(viewController, animation: .interactiveFade)
         case let .user(username):
             var vc = UserViewController.instantiateFromNib()
@@ -55,22 +52,35 @@ class UserCoordinator: NavigationCoordinator<UserRoute> {
     private func addPushGestureRecognizer() {
         let gestureRecognizer = UIScreenEdgePanGestureRecognizer()
         gestureRecognizer.edges = .right
+
         let topView = (rootViewController.topViewController ?? rootViewController)?.view
         topView?.addGestureRecognizer(gestureRecognizer)
+
         registerInteractiveTransition(
-            for: .emptyForAnimation,
+            for: .randomColor,
             triggeredBy: gestureRecognizer,
-            progression: { [weak topView] recognizer in
+            progress: { [weak topView] recognizer in
                 let xTranslation = -recognizer.translation(in: topView).x
                 return max(min(xTranslation / UIScreen.main.bounds.width, 1), 0)
             },
             shouldFinish: { [weak topView] recognizer in
                 let xTranslation = -recognizer.translation(in: topView).x
                 let xVelocity = -recognizer.velocity(in: topView).x
-                return xTranslation / UIScreen.main.bounds.width >= 0.5
+                return xTranslation >= UIScreen.main.bounds.width / 2
                     || xVelocity >= UIScreen.main.bounds.width / 2
             },
             completion: nil
+        )
+    }
+}
+
+extension UIColor {
+    fileprivate static func random(alpha: CGFloat? = 1) -> UIColor {
+        return UIColor(
+            red: CGFloat.random(in: 0...1),
+            green: CGFloat.random(in: 0...1),
+            blue: CGFloat.random(in: 0...1),
+            alpha: alpha ?? CGFloat.random(in: 0...1)
         )
     }
 }

--- a/XCoordinator/Classes/BaseCoordinator.swift
+++ b/XCoordinator/Classes/BaseCoordinator.swift
@@ -68,41 +68,40 @@ open class BaseCoordinator<RouteType: Route, TransitionType: TransitionProtocol>
     }
 }
 
-// MARK: - BaseCoordinator: UIGestureRecognizerTargets
+// MARK: - BaseCoordinator+UIGestureRecognizer
 
 extension BaseCoordinator {
     open func registerGestureRecognizer(
         _ recognizer: UIGestureRecognizer,
         route: RouteType,
         progression: @escaping (UIGestureRecognizer) -> CGFloat,
-        shouldFinish: @escaping (UIGestureRecognizer) -> Bool
-        ) {
-        var _transition: TransitionType?
+        shouldFinish: @escaping (UIGestureRecognizer) -> Bool,
+        completion: PresentationHandler? = nil) {
 
+        var animation: TransitionAnimation?
         let target = GestureRecognizerTarget(recognizer: recognizer) { [weak self] recognizer in
             guard let `self` = self else { return }
-
-            let transition = _transition ?? self.prepareTransition(for: route)
-            _transition = transition
 
             switch recognizer.state {
             case .possible, .failed:
                 break
             case .began:
-                transition.animation?.start()
-                self.performTransition(transition, with: TransitionOptions(animated: true))
+                let transition = self.prepareTransition(for: route)
+                animation = transition.animation
+                animation?.start()
+                self.performTransition(transition, with: TransitionOptions(animated: true), completion: completion)
             case .changed:
                 let transitionProgress = progression(recognizer)
-                transition.animation?.interactionController?.update(transitionProgress)
+                animation?.interactionController?.update(transitionProgress)
             case .cancelled:
-                defer { transition.animation?.cleanup() }
-                transition.animation?.interactionController?.cancel()
+                defer { animation?.cleanup() }
+                animation?.interactionController?.cancel()
             case .ended:
-                defer { transition.animation?.cleanup() }
+                defer { animation?.cleanup() }
                 if shouldFinish(recognizer) {
-                    transition.animation?.interactionController?.finish()
+                    animation?.interactionController?.finish()
                 } else {
-                    transition.animation?.interactionController?.cancel()
+                    animation?.interactionController?.cancel()
                 }
             }
         }

--- a/XCoordinator/Classes/BaseCoordinator.swift
+++ b/XCoordinator/Classes/BaseCoordinator.swift
@@ -74,7 +74,7 @@ extension BaseCoordinator {
     open func registerInteractiveTransition<GestureRecognizer: UIGestureRecognizer>(
         for route: RouteType,
         triggeredBy recognizer: GestureRecognizer,
-        progression: @escaping (GestureRecognizer) -> CGFloat,
+        progress: @escaping (GestureRecognizer) -> CGFloat,
         shouldFinish: @escaping (GestureRecognizer) -> Bool,
         completion: PresentationHandler? = nil) {
 
@@ -95,8 +95,7 @@ extension BaseCoordinator {
                     completion: completion
                 )
             case .changed:
-                let transitionProgress = progression(recognizer)
-                animation?.interactionController?.update(transitionProgress)
+                animation?.interactionController?.update(progress(recognizer))
             case .cancelled:
                 defer { animation?.cleanup() }
                 animation?.interactionController?.cancel()

--- a/XCoordinator/Classes/BaseCoordinator.swift
+++ b/XCoordinator/Classes/BaseCoordinator.swift
@@ -78,6 +78,22 @@ extension BaseCoordinator {
         shouldFinish: @escaping (GestureRecognizer) -> Bool,
         completion: PresentationHandler? = nil) {
 
+        return registerInteractiveTransition(
+            { [weak self] in self?.prepareTransition(for: route) ?? .none() },
+            triggeredBy: recognizer,
+            progress: progress,
+            shouldFinish: shouldFinish,
+            completion: completion
+        )
+    }
+
+    private func registerInteractiveTransition<GestureRecognizer: UIGestureRecognizer>(
+        _ transitionGenerator: @escaping () -> TransitionType,
+        triggeredBy recognizer: GestureRecognizer,
+        progress: @escaping (GestureRecognizer) -> CGFloat,
+        shouldFinish: @escaping (GestureRecognizer) -> Bool,
+        completion: PresentationHandler? = nil) {
+
         var animation: TransitionAnimation?
         let target = Target(recognizer: recognizer) { [weak self] recognizer in
             guard let `self` = self else { return }
@@ -86,7 +102,7 @@ extension BaseCoordinator {
             case .possible, .failed:
                 break
             case .began:
-                let transition = self.prepareTransition(for: route)
+                let transition = transitionGenerator()
                 animation = transition.animation
                 animation?.start()
                 self.performTransition(

--- a/XCoordinator/Classes/DeepLinking.swift
+++ b/XCoordinator/Classes/DeepLinking.swift
@@ -28,7 +28,7 @@ extension Coordinator where Self: AnyObject {
 
 extension Transition {
     fileprivate static func deepLink<C: Coordinator & AnyObject>(with coordinator: C, _ route: C.RouteType, array remainingRoutes: [Route]) -> Transition {
-        return Transition(presentables: []) { [weak coordinator] options, performer, completion in
+        return Transition(presentables: [], animation: nil) { [weak coordinator] options, performer, completion in
             guard let coordinator = coordinator else {
                 assertionFailure("Please use the coordinator responsible for executing a deepLink-Transition when initializing.")
                 completion?()

--- a/XCoordinator/Classes/GestureRecognizerTarget.swift
+++ b/XCoordinator/Classes/GestureRecognizerTarget.swift
@@ -7,16 +7,20 @@
 
 import Foundation
 
-internal class GestureRecognizerTarget {
+internal protocol GestureRecognizerTarget {
+    var gestureRecognizer: UIGestureRecognizer? { get }
+}
+
+internal class Target<GestureRecognizer: UIGestureRecognizer>: GestureRecognizerTarget {
 
     // MARK: - Stored properties
 
-    private var handler: (UIGestureRecognizer) -> Void
-    internal weak var gestureRecognizer: UIGestureRecognizer?
+    private let handler: (GestureRecognizer) -> Void
+    internal private(set) weak var gestureRecognizer: UIGestureRecognizer?
 
     // MARK: - Init
 
-    init(recognizer gestureRecognizer: UIGestureRecognizer, handler: @escaping (UIGestureRecognizer) -> Void) {
+    init(recognizer gestureRecognizer: GestureRecognizer, handler: @escaping (GestureRecognizer) -> Void) {
         self.handler = handler
         self.gestureRecognizer = gestureRecognizer
         gestureRecognizer.addTarget(self, action: #selector(handle))
@@ -25,7 +29,8 @@ internal class GestureRecognizerTarget {
     // MARK: - Target actions
 
     @objc
-    open func handle(_ gestureRecognizer: UIGestureRecognizer) {
-        handler(gestureRecognizer)
+    private func handle(_ gestureRecognizer: UIGestureRecognizer) {
+        guard let recognizer = gestureRecognizer as? GestureRecognizer else { return }
+        handler(recognizer)
     }
 }

--- a/XCoordinator/Classes/GestureRecognizerTarget.swift
+++ b/XCoordinator/Classes/GestureRecognizerTarget.swift
@@ -1,0 +1,31 @@
+//
+//  GestureRecognizerTarget.swift
+//  XCoordinator
+//
+//  Created by Paul Kraft on 19.12.18.
+//
+
+import Foundation
+
+internal class GestureRecognizerTarget {
+
+    // MARK: - Stored properties
+
+    private var handler: (UIGestureRecognizer) -> Void
+    internal weak var gestureRecognizer: UIGestureRecognizer?
+
+    // MARK: - Init
+
+    init(recognizer gestureRecognizer: UIGestureRecognizer, handler: @escaping (UIGestureRecognizer) -> Void) {
+        self.handler = handler
+        self.gestureRecognizer = gestureRecognizer
+        gestureRecognizer.addTarget(self, action: #selector(handle))
+    }
+
+    // MARK: - Target actions
+
+    @objc
+    open func handle(_ gestureRecognizer: UIGestureRecognizer) {
+        handler(gestureRecognizer)
+    }
+}

--- a/XCoordinator/Classes/NavigationTransition.swift
+++ b/XCoordinator/Classes/NavigationTransition.swift
@@ -10,7 +10,7 @@ public typealias NavigationTransition = Transition<UINavigationController>
 
 extension Transition where RootViewController: UINavigationController {
     public static func push(_ presentable: Presentable, animation: Animation? = nil) -> NavigationTransition {
-        return NavigationTransition(presentables: [presentable]) { options, performer, completion in
+        return NavigationTransition(presentables: [presentable], animation: animation?.presentationAnimation) { options, performer, completion in
             performer.push(
                 presentable.viewController,
                 with: options,
@@ -24,7 +24,7 @@ extension Transition where RootViewController: UINavigationController {
     }
 
     public static func pop(animation: Animation? = nil) -> NavigationTransition {
-        return NavigationTransition(presentables: []) { options, performer, completion in
+        return NavigationTransition(presentables: [], animation: animation?.dismissalAnimation) { options, performer, completion in
             performer.pop(
                 toRoot: false,
                 with: options,
@@ -35,7 +35,7 @@ extension Transition where RootViewController: UINavigationController {
     }
 
     public static func pop(to presentable: Presentable, animation: Animation? = nil) -> NavigationTransition {
-        return NavigationTransition(presentables: [presentable]) { options, performer, completion in
+        return NavigationTransition(presentables: [presentable], animation: animation?.dismissalAnimation) { options, performer, completion in
             performer.pop(
                 to: presentable.viewController,
                 options: options,
@@ -46,7 +46,7 @@ extension Transition where RootViewController: UINavigationController {
     }
 
     public static func popToRoot(animation: Animation? = nil) -> NavigationTransition {
-        return NavigationTransition(presentables: []) { options, performer, completion in
+        return NavigationTransition(presentables: [], animation: animation?.dismissalAnimation) { options, performer, completion in
             performer.pop(
                 toRoot: true,
                 with: options,
@@ -57,7 +57,7 @@ extension Transition where RootViewController: UINavigationController {
     }
 
     public static func set(_ presentables: [Presentable], animation: Animation? = nil) -> NavigationTransition {
-        return NavigationTransition(presentables: presentables) { options, performer, completion in
+        return NavigationTransition(presentables: presentables, animation: animation?.presentationAnimation) { options, performer, completion in
             performer.set(
                 presentables.map { $0.viewController },
                 with: options,

--- a/XCoordinator/Classes/PageTransition.swift
+++ b/XCoordinator/Classes/PageTransition.swift
@@ -11,7 +11,7 @@ public typealias PageTransition = Transition<UIPageViewController>
 extension Transition where RootViewController: UIPageViewController {
     public static func set(_ first: Presentable, _ second: Presentable? = nil, direction: UIPageViewController.NavigationDirection) -> PageTransition {
         let presentables = [first, second].compactMap { $0 }
-        return PageTransition(presentables: presentables) { options, performer, completion in
+        return PageTransition(presentables: presentables, animation: nil) { options, performer, completion in
             performer.set(
                 presentables.map { $0.viewController },
                 direction: direction,

--- a/XCoordinator/Classes/SplitTransition.swift
+++ b/XCoordinator/Classes/SplitTransition.swift
@@ -10,7 +10,7 @@ public typealias SplitTransition = Transition<UISplitViewController>
 
 extension Transition where RootViewController: UISplitViewController {
     public static func show(_ presentable: Presentable) -> SplitTransition {
-        return SplitTransition(presentables: [presentable]) { options, performer, completion in
+        return SplitTransition(presentables: [presentable], animation: nil) { options, performer, completion in
             performer.show(
                 presentable.viewController,
                 with: options,
@@ -23,7 +23,7 @@ extension Transition where RootViewController: UISplitViewController {
     }
 
     public static func showDetail(_ presentable: Presentable) -> SplitTransition {
-        return SplitTransition(presentables: [presentable]) { options, performer, completion in
+        return SplitTransition(presentables: [presentable], animation: nil) { options, performer, completion in
             performer.showDetail(
                 presentable.viewController,
                 with: options,

--- a/XCoordinator/Classes/TabBarTransition.swift
+++ b/XCoordinator/Classes/TabBarTransition.swift
@@ -10,7 +10,7 @@ public typealias TabBarTransition = Transition<UITabBarController>
 
 extension Transition where RootViewController: UITabBarController {
     public static func set(_ presentables: [Presentable], animation: Animation? = nil) -> TabBarTransition {
-        return TabBarTransition(presentables: presentables) { options, performer, completion in
+        return TabBarTransition(presentables: presentables, animation: animation?.presentationAnimation) { options, performer, completion in
             performer.set(
                 presentables.map { $0.viewController },
                 with: options,
@@ -21,7 +21,7 @@ extension Transition where RootViewController: UITabBarController {
     }
 
     public static func select(_ presentable: Presentable, animation: Animation? = nil) -> TabBarTransition {
-        return TabBarTransition(presentables: [presentable]) { options, performer, completion in
+        return TabBarTransition(presentables: [presentable], animation: animation?.presentationAnimation) { options, performer, completion in
             performer.select(
                 presentable.viewController,
                 with: options,
@@ -32,7 +32,7 @@ extension Transition where RootViewController: UITabBarController {
     }
 
     public static func select(index: Int, animation: Animation? = nil) -> TabBarTransition {
-        return TabBarTransition(presentables: []) { options, performer, completion in
+        return TabBarTransition(presentables: [], animation: animation?.presentationAnimation) { options, performer, completion in
             performer.select(
                 index: index,
                 with: options,

--- a/XCoordinator/Classes/Transition+Init.swift
+++ b/XCoordinator/Classes/Transition+Init.swift
@@ -8,7 +8,7 @@
 
 extension Transition {
     public static func presentOnRoot(_ presentable: Presentable, animation: Animation? = nil) -> Transition {
-        return Transition(presentables: [presentable]) { options, performer, completion in
+        return Transition(presentables: [presentable], animation: animation?.presentationAnimation) { options, performer, completion in
             performer.present(
                 onRoot: true,
                 presentable.viewController,
@@ -21,7 +21,7 @@ extension Transition {
     }
 
     public static func present(_ presentable: Presentable, animation: Animation? = nil) -> Transition {
-        return Transition(presentables: [presentable]) { options, performer, completion in
+        return Transition(presentables: [presentable], animation: animation?.presentationAnimation) { options, performer, completion in
             performer.present(
                 onRoot: false,
                 presentable.viewController,
@@ -34,7 +34,7 @@ extension Transition {
     }
 
     public static func embed(_ presentable: Presentable, in container: Container) -> Transition {
-        return Transition(presentables: [presentable]) { options, performer, completion in
+        return Transition(presentables: [presentable], animation: nil) { options, performer, completion in
             performer.embed(
                 presentable.viewController,
                 in: container,
@@ -46,7 +46,7 @@ extension Transition {
     }
 
     public static func dismissToRoot(animation: Animation? = nil) -> Transition {
-        return Transition(presentables: []) { options, performer, completion in
+        return Transition(presentables: [], animation: animation?.dismissalAnimation) { options, performer, completion in
             performer.dismiss(
                 toRoot: true,
                 with: options,
@@ -57,7 +57,7 @@ extension Transition {
     }
 
     public static func dismiss(animation: Animation? = nil) -> Transition {
-        return Transition(presentables: []) { options, performer, completion in
+        return Transition(presentables: [], animation: animation?.dismissalAnimation) { options, performer, completion in
             performer.dismiss(
                 toRoot: false,
                 with: options,
@@ -68,13 +68,13 @@ extension Transition {
     }
 
     public static func none() -> Transition {
-        return Transition(presentables: []) { options, performer, completion in
+        return Transition(presentables: [], animation: nil) { options, performer, completion in
             completion?()
         }
     }
 
     public static func multiple<C: Collection>(_ transitions: C) -> Transition where C.Element == Transition {
-        return Transition(presentables: transitions.flatMap { $0.presentables }) { options, performer, completion in
+        return Transition(presentables: transitions.flatMap { $0.presentables }, animation: nil) { options, performer, completion in
             guard let firstTransition = transitions.first else {
                 completion?()
                 return
@@ -92,21 +92,21 @@ extension Transition {
 
     public static func route<C: Coordinator>(_ route: C.RouteType, on coordinator: C) -> Transition {
         let transition = coordinator.prepareTransition(for: route)
-        return Transition(presentables: transition.presentables) { options, _, completion in
+        return Transition(presentables: transition.presentables, animation: transition.animation) { options, _, completion in
             coordinator.performTransition(transition, with: options, completion: completion)
         }
     }
 
     /// Peeking is not supported with Transition.trigger. If needed, use Transition.route instead.
     public static func trigger<R: Router>(_ route: R.RouteType, on router: R) -> Transition {
-        return Transition(presentables: []) { options, _, completion in
+        return Transition(presentables: [], animation: nil) { options, _, completion in
             router.trigger(route, with: options, completion: completion)
         }
     }
 
     @available(iOS 9.0, *)
     public static func registerPeek(for source: Container, transition: @escaping @autoclosure () -> Transition) -> Transition {
-        return Transition(presentables: []) { options, performer, completion in
+        return Transition(presentables: [], animation: nil) { options, performer, completion in
             return performer.registerPeek(
                 from: source.view,
                 transitionGenerator: { transition() },

--- a/XCoordinator/Classes/Transition.swift
+++ b/XCoordinator/Classes/Transition.swift
@@ -15,6 +15,7 @@ public struct Transition<RootViewController: UIViewController>: TransitionProtoc
     // MARK: - Stored properties
 
     private var _presentables: [Presentable]
+    private var _animation: TransitionAnimation?
     private var _perform: Perform
 
     // MARK: - Computed properties
@@ -23,10 +24,15 @@ public struct Transition<RootViewController: UIViewController>: TransitionProtoc
         return _presentables
     }
 
+    public var animation: TransitionAnimation? {
+        return _animation
+    }
+
     // MARK: - Init
 
-    public init(presentables: [Presentable], perform: @escaping Perform) {
+    public init(presentables: [Presentable], animation: TransitionAnimation?, perform: @escaping Perform) {
         self._presentables = presentables
+        self._animation = animation
         self._perform = perform
     }
 

--- a/XCoordinator/Classes/TransitionProtocol.swift
+++ b/XCoordinator/Classes/TransitionProtocol.swift
@@ -10,6 +10,8 @@ public protocol TransitionProtocol {
     associatedtype RootViewController: UIViewController
 
     var presentables: [Presentable] { get }
+    var animation: TransitionAnimation? { get }
+
     func perform<C: Coordinator>(options: TransitionOptions, coordinator: C, completion: PresentationHandler?) where C.TransitionType == Self
 
     // MARK: - Always accessible transitions


### PR DESCRIPTION
Planned for 1.1.0.

In any coordinator that is a subclass of BaseCoordinator, you can call registerInteractiveTransition(...) to register a gestureRecognizer to trigger a transition, e.g. useful for opening a side-menu or pushing a viewController with a reversed pop-gesture (as shown in Example-app).

- [x] Add BaseCoordinator.registerInteractiveTransition(...) to enable the addition of interactive routes by registering gesture recognizers
- [x] Add example to Example app (done in UserCoordinator)