### PR TITLE
PageCoordinator memory leaks

### DIFF
--- a/XCoordinator.podspec
+++ b/XCoordinator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name         = 'XCoordinator'
-    spec.version      = '1.2.3'
+    spec.version      = '1.2.4'
     spec.license      = { :type => 'MIT' }
     spec.homepage     = 'https://github.com/quickbirdstudios/XCoordinator'
     spec.authors      = { 'Stefan Kofler' => 'stefan.kofler@quickbirdstudios.com', 'Paul Kraft' => 'pauljohannes.kraft@quickbirdstudios.com' }

--- a/XCoordinator/Classes/PageCoordinator.swift
+++ b/XCoordinator/Classes/PageCoordinator.swift
@@ -29,7 +29,7 @@ open class PageCoordinator<RouteType: Route>: BaseCoordinator<RouteType, PageTra
             return
         }
 
-        super.init(initialTransition: .set(firstPage, direction: direction))
+        super.init(initialTransition: .multiple(.initial(pages: pages), .set(firstPage, direction: direction)))
     }
 
     // MARK: - Overrides

--- a/XCoordinator/Classes/PageTransition.swift
+++ b/XCoordinator/Classes/PageTransition.swift
@@ -22,4 +22,15 @@ extension Transition where RootViewController: UIPageViewController {
             }
         }
     }
+
+    static func initial(pages: [Presentable]) -> Transition {
+        return Transition(presentables: pages, animation: nil) { _, performer, completion in
+            CATransaction.begin()
+            CATransaction.setCompletionBlock {
+                pages.forEach { $0.presented(from: performer) }
+                completion?()
+            }
+            CATransaction.commit()
+        }
+    }
 }


### PR DESCRIPTION
Planned for 1.2.4

This should fix all memory leaks related to PageCoordinator, especially since it did not ensure to call presented(from:) for all pages before.