### PR TITLE
Add Example app UITest

### DIFF
--- a/Example/UITests/UITests.swift
+++ b/Example/UITests/UITests.swift
@@ -28,40 +28,40 @@ class XCoordinator_ExampleUITests: XCTestCase {
 
     func testNavigation() {
         let app = XCUIApplication()
-        clickThroughTabHomeFromLogin(app: app)
-        clickThroughSplitHomeFromLogin(app: app)
-        clickThroughPageHomeFromLogin(app: app)
+        navigateTabHomeFromLogin(app: app)
+        navigateSplitHomeFromLogin(app: app)
+        navigatePageHomeFromLogin(app: app)
     }
 
     // MARK: - Helpers
 
-    private func clickThroughPageHomeFromLogin(app: XCUIApplication) {
+    private func navigatePageHomeFromLogin(app: XCUIApplication) {
         app.buttons["Login"].tap()
         app.swipeLeft()
-        clickThroughNewsDetailScreenFromNews(app: app, trySwiping: false)
+        navigateNewsDetailFromNews(app: app, trySwiping: false)
         app.swipeRight()
-        clickThroughUserScreenFromHome(app: app)
+        navigateUserFromUserList(app: app)
         app.buttons["Logout"].tap()
     }
 
-    private func clickThroughSplitHomeFromLogin(app: XCUIApplication) {
+    private func navigateSplitHomeFromLogin(app: XCUIApplication) {
         app.buttons["Login"].tap()
-        clickThroughNewsDetailScreenFromNews(app: app, trySwiping: true)
+        navigateNewsDetailFromNews(app: app, trySwiping: true)
         app.navigationBars.buttons["Home"].tap()
-        clickThroughUserScreenFromHome(app: app)
+        navigateUserFromUserList(app: app)
         app.buttons["Logout"].tap()
     }
 
-    private func clickThroughTabHomeFromLogin(app: XCUIApplication) {
+    private func navigateTabHomeFromLogin(app: XCUIApplication) {
         app.buttons["Login"].tap()
         app.tabBars.buttons["Recents"].tap()
-        clickThroughNewsDetailScreenFromNews(app: app, trySwiping: true)
+        navigateNewsDetailFromNews(app: app, trySwiping: true)
         app.tabBars.buttons["More"].tap()
-        clickThroughUserScreenFromHome(app: app)
+        navigateUserFromUserList(app: app)
         app.buttons["Logout"].tap()
     }
 
-    private func clickThroughNewsDetailScreenFromNews(app: XCUIApplication, trySwiping: Bool) {
+    private func navigateNewsDetailFromNews(app: XCUIApplication, trySwiping: Bool) {
         app.tables.staticTexts["Example article 0"].tap()
         if trySwiping {
             let window = app.children(matching: .window).element(boundBy: 1)
@@ -71,7 +71,7 @@ class XCoordinator_ExampleUITests: XCTestCase {
         app.navigationBars.buttons["QuickBird Studios Blog"].tap()
     }
 
-    private func clickThroughUserScreenFromHome(app: XCUIApplication) {
+    private func navigateUserFromUserList(app: XCUIApplication) {
         app.buttons["Users"].tap()
         app.tables/*@START_MENU_TOKEN@*/.staticTexts["Stefan"]/*[[".cells.staticTexts[\"Stefan\"]",".staticTexts[\"Stefan\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
         app.buttons["Show alert"].tap()

--- a/Example/UITests/UITests.swift
+++ b/Example/UITests/UITests.swift
@@ -25,15 +25,63 @@ class XCoordinator_ExampleUITests: XCTestCase {
         // In UI tests it’s important to set the initial state - such as interface orientation -
         // required for your tests before they run. The setUp method is a good place to do this.
     }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
+
+    func testNavigation() {
+        let app = XCUIApplication()
+        clickThroughTabHomeFromLogin(app: app)
+        clickThroughSplitHomeFromLogin(app: app)
+        clickThroughPageHomeFromLogin(app: app)
     }
-    
-    func testExample() {
-        // Use recording to get started writing UI tests.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+
+    // MARK: - Helpers
+
+    private func clickThroughPageHomeFromLogin(app: XCUIApplication) {
+        app.buttons["Login"].tap()
+        app.swipeLeft()
+        clickThroughNewsDetailScreenFromNews(app: app, trySwiping: false)
+        app.swipeRight()
+        clickThroughUserScreenFromHome(app: app)
+        app.buttons["Logout"].tap()
     }
-    
+
+    private func clickThroughSplitHomeFromLogin(app: XCUIApplication) {
+        app.buttons["Login"].tap()
+        clickThroughNewsDetailScreenFromNews(app: app, trySwiping: true)
+        app.navigationBars.buttons["Home"].tap()
+        clickThroughUserScreenFromHome(app: app)
+        app.buttons["Logout"].tap()
+    }
+
+    private func clickThroughTabHomeFromLogin(app: XCUIApplication) {
+        app.buttons["Login"].tap()
+        app.tabBars.buttons["Recents"].tap()
+        clickThroughNewsDetailScreenFromNews(app: app, trySwiping: true)
+        app.tabBars.buttons["More"].tap()
+        clickThroughUserScreenFromHome(app: app)
+        app.buttons["Logout"].tap()
+    }
+
+    private func clickThroughNewsDetailScreenFromNews(app: XCUIApplication, trySwiping: Bool) {
+        app.tables.staticTexts["Example article 0"].tap()
+        if trySwiping {
+            let window = app.children(matching: .window).element(boundBy: 1)
+            window.edgeSwipeLeft()
+            app.tables.staticTexts["Example article 0"].tap()
+        }
+        app.navigationBars.buttons["QuickBird Studios Blog"].tap()
+    }
+
+    private func clickThroughUserScreenFromHome(app: XCUIApplication) {
+        app.buttons["Users"].tap()
+        app.tables/*@START_MENU_TOKEN@*/.staticTexts["Stefan"]/*[[".cells.staticTexts[\"Stefan\"]",".staticTexts[\"Stefan\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        app.buttons["Show alert"].tap()
+        app.alerts["Hey"].buttons["Ok"].tap()
+        let window = app.children(matching: .window).element(boundBy: 1)
+        window.edgeSwipeRight()
+        app.navigationBars.buttons["Back"].tap()
+        window.edgeSwipeRight()
+        window.edgeSwipeLeft()
+        app.navigationBars.buttons["Close"].tap()
+        app.navigationBars.buttons["Home"].tap()
+    }
 }

--- a/Example/UITests/XCUIElement+EdgeSwipe.swift
+++ b/Example/UITests/XCUIElement+EdgeSwipe.swift
@@ -1,0 +1,23 @@
+//
+//  XCUIElement+EdgeSwipe.swift
+//  XCoordinator_UITests
+//
+//  Created by Paul Kraft on 05.03.19.
+//  Copyright © 2019 QuickBird Studios. All rights reserved.
+//
+
+import XCTest
+
+extension XCUIElement {
+    func edgeSwipeLeft() {
+        let firstCoordinate = coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0.5))
+        let secondCoordinate = coordinate(withNormalizedOffset: CGVector(dx: 0.6, dy: 0.5))
+        firstCoordinate.press(forDuration: 0.01, thenDragTo: secondCoordinate)
+    }
+
+    func edgeSwipeRight() {
+        let firstCoordinate = coordinate(withNormalizedOffset: CGVector(dx: 1, dy: 0.5))
+        let secondCoordinate = coordinate(withNormalizedOffset: CGVector(dx: 0.4, dy: 0.5))
+        firstCoordinate.press(forDuration: 0.01, thenDragTo: secondCoordinate)
+    }
+}

--- a/Example/XCoordinator.xcodeproj/project.pbxproj
+++ b/Example/XCoordinator.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		9B07F06B21D6D44200A0C149 /* Animation+Swirl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B07F06A21D6D44200A0C149 /* Animation+Swirl.swift */; };
 		9B33481321C47F9700E954A3 /* Presentable+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B33481221C47F9700E954A3 /* Presentable+Rx.swift */; };
 		9B33481821C4804600E954A3 /* Coordinator+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B33481721C4804600E954A3 /* Coordinator+Rx.swift */; };
+		9BA54440222EF5B0000556DC /* XCUIElement+EdgeSwipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA5443F222EF5B0000556DC /* XCUIElement+EdgeSwipe.swift */; };
 		9BC60AFE214EA6AA00ECFF9A /* AnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC60AFC214EA6A500ECFF9A /* AnimationTests.swift */; };
 		9BC60B00214EA71300ECFF9A /* TestAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC60AFF214EA71300ECFF9A /* TestAnimation.swift */; };
 		9BC60B1A214EF8D900ECFF9A /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC60B19214EF8D900ECFF9A /* UITests.swift */; };
@@ -100,6 +101,7 @@
 		9B07F06A21D6D44200A0C149 /* Animation+Swirl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Animation+Swirl.swift"; sourceTree = "<group>"; };
 		9B33481221C47F9700E954A3 /* Presentable+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Presentable+Rx.swift"; sourceTree = "<group>"; };
 		9B33481721C4804600E954A3 /* Coordinator+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Coordinator+Rx.swift"; sourceTree = "<group>"; };
+		9BA5443F222EF5B0000556DC /* XCUIElement+EdgeSwipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+EdgeSwipe.swift"; sourceTree = "<group>"; };
 		9BC60AFC214EA6A500ECFF9A /* AnimationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationTests.swift; sourceTree = "<group>"; };
 		9BC60AFF214EA71300ECFF9A /* TestAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAnimation.swift; sourceTree = "<group>"; };
 		9BC60B17214EF8D900ECFF9A /* XCoordinator_UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XCoordinator_UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -282,6 +284,7 @@
 			isa = PBXGroup;
 			children = (
 				9BC60B19214EF8D900ECFF9A /* UITests.swift */,
+				9BA5443F222EF5B0000556DC /* XCUIElement+EdgeSwipe.swift */,
 				9BC60B1B214EF8D900ECFF9A /* Info.plist */,
 			);
 			path = UITests;
@@ -726,6 +729,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9BC60B1A214EF8D900ECFF9A /* UITests.swift in Sources */,
+				9BA54440222EF5B0000556DC /* XCUIElement+EdgeSwipe.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/XCoordinator/Coordinators/AppCoordinator.swift
+++ b/Example/XCoordinator/Coordinators/AppCoordinator.swift
@@ -40,14 +40,13 @@ class AppCoordinator: NavigationCoordinator<AppRoute> {
             viewController.bind(to: viewModel)
             return .push(viewController)
         case .home:
-            defer { homeRouteTriggerCount += 1 }
-
             let presentables: [Presentable] = [
                 HomeTabCoordinator(),
                 HomeSplitCoordinator(),
                 HomePageCoordinator()
             ]
             let presentable = presentables[homeRouteTriggerCount % presentables.count]
+            homeRouteTriggerCount = (homeRouteTriggerCount + 1) % presentables.count
             self.home = presentable
             return .present(presentable, animation: .fade)
         case .newsDetail(let news):

--- a/Example/XCoordinator/Coordinators/AppCoordinator.swift
+++ b/Example/XCoordinator/Coordinators/AppCoordinator.swift
@@ -22,6 +22,7 @@ class AppCoordinator: NavigationCoordinator<AppRoute> {
     // We need to keep a reference to the HomeCoordinator
     // as it is not held by any viewModel or viewController
     private var home: Presentable?
+    private var homeRouteTriggerCount = 0
 
     // MARK: - Init
 
@@ -39,14 +40,14 @@ class AppCoordinator: NavigationCoordinator<AppRoute> {
             viewController.bind(to: viewModel)
             return .push(viewController)
         case .home:
-            guard let presentable: Presentable =
-                [
-                    HomeTabCoordinator(),
-                    HomeSplitCoordinator(),
-                    HomePageCoordinator()
-                ].randomElement() else {
-                    return .none()
-            }
+            defer { homeRouteTriggerCount += 1 }
+
+            let presentables: [Presentable] = [
+                HomeTabCoordinator(),
+                HomeSplitCoordinator(),
+                HomePageCoordinator()
+            ]
+            let presentable = presentables[homeRouteTriggerCount % presentables.count]
             self.home = presentable
             return .present(presentable, animation: .fade)
         case .newsDetail(let news):


### PR DESCRIPTION
Planned for 1.4.1

Adds a UITest navigating through the whole app once - it may not trigger all routes for now (e.g. peek/pop). Most routes should and are covered though. Changes to this UITest will be needed once the structure of the example app changes. It will however notify about problems possibly occuring in the Example app (see https://github.com/quickbirdstudios/XCoordinator/issues/59 for example).