### PR TITLE
RxSwift 5.0 + Action 4.0 Updates

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -4,7 +4,7 @@ platform :ios, '8.0'
 target 'XCoordinator_Example' do
   pod 'XCoordinator', :path => '../'
   pod 'XCoordinator/RxSwift', :path => '../'
-  pod 'Action', '~> 3.9'
+  pod 'Action', '~> 4.0'
   pod 'SwiftLint'
 
   target 'XCoordinator_Tests' do

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,22 +1,23 @@
 PODS:
-  - Action (3.11.0):
-    - RxCocoa (~> 4.0)
-    - RxSwift (~> 4.0)
-  - RxAtomic (4.4.2)
-  - RxCocoa (4.4.2):
-    - RxSwift (>= 4.4.2, ~> 4.4)
-  - RxSwift (4.4.2):
-    - RxAtomic (>= 4.4.2, ~> 4.4)
-  - SwiftLint (0.31.0)
-  - XCoordinator (1.4.0):
-    - XCoordinator/Core (= 1.4.0)
-  - XCoordinator/Core (1.4.0)
-  - XCoordinator/RxSwift (1.4.0):
-    - RxSwift (~> 4.0)
+  - Action (4.0.0):
+    - RxCocoa (~> 5.0)
+    - RxSwift (~> 5.0)
+  - RxCocoa (5.0.0):
+    - RxRelay (~> 5)
+    - RxSwift (~> 5)
+  - RxRelay (5.0.0):
+    - RxSwift (~> 5)
+  - RxSwift (5.0.0)
+  - SwiftLint (0.32.0)
+  - XCoordinator (1.5.0):
+    - XCoordinator/Core (= 1.5.0)
+  - XCoordinator/Core (1.5.0)
+  - XCoordinator/RxSwift (1.5.0):
+    - RxSwift (~> 5.0)
     - XCoordinator/Core
 
 DEPENDENCIES:
-  - Action (~> 3.9)
+  - Action (~> 4.0)
   - SwiftLint
   - XCoordinator (from `../`)
   - XCoordinator/RxSwift (from `../`)
@@ -24,8 +25,8 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - Action
-    - RxAtomic
     - RxCocoa
+    - RxRelay
     - RxSwift
     - SwiftLint
 
@@ -34,13 +35,13 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Action: 689181e4c3f6566844178d8a7da6fef39a9597fc
-  RxAtomic: d00e97c10db88c6f08540e0bf2752fc5a2404167
-  RxCocoa: 477990dc3b4c3ff55fb0ac77e1cc06244e0aaec8
-  RxSwift: 74c29b693c8e42b0f64400e8b06564575742d649
-  SwiftLint: 7a0227733d786395817373b2d0ca799fd0093ff3
-  XCoordinator: c24865c3722779f716551e63da71ce64ece576fb
+  Action: 0d14986aad0f1330aa27ce65d0cdeaacbb63d91c
+  RxCocoa: fcf32050ac00d801f34a7f71d5e8e7f23026dcd8
+  RxRelay: 4f7409406a51a55cd88483f21ed898c234d60f18
+  RxSwift: 8b0671caa829a763bbce7271095859121cbd895f
+  SwiftLint: 009a898ef2a1c851f45e1b59349bf6ff2ddc990d
+  XCoordinator: df2e64a11dd4b4ee8f27ea84c58d5ff3a83aaf81
 
-PODFILE CHECKSUM: 14c5bdcd898ea0f09e76fcd87a67d54de2725512
+PODFILE CHECKSUM: dee620dc7de83e80e4178075f597422fd86646a9
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.1

--- a/Example/XCoordinator.xcodeproj/project.pbxproj
+++ b/Example/XCoordinator.xcodeproj/project.pbxproj
@@ -626,24 +626,24 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-XCoordinator_Example/Pods-XCoordinator_Example-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-XCoordinator_Example/Pods-XCoordinator_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Action/Action.framework",
-				"${BUILT_PRODUCTS_DIR}/RxAtomic/RxAtomic.framework",
 				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
+				"${BUILT_PRODUCTS_DIR}/RxRelay/RxRelay.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/XCoordinator/XCoordinator.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Action.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxAtomic.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxRelay.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/XCoordinator.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-XCoordinator_Example/Pods-XCoordinator_Example-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-XCoordinator_Example/Pods-XCoordinator_Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9B07F06C21D6FADA00A0C149 /* ShellScript */ = {

--- a/Example/XCoordinator/Scenes/Home/HomeViewModel.swift
+++ b/Example/XCoordinator/Scenes/Home/HomeViewModel.swift
@@ -11,8 +11,8 @@ import RxSwift
 import XCoordinator
 
 protocol HomeViewModelInput {
-    var logoutTrigger: InputSubject<Void> { get }
-    var usersTrigger: InputSubject<Void> { get }
+    var logoutTrigger: AnyObserver<Void> { get }
+    var usersTrigger: AnyObserver<Void> { get }
 }
 
 protocol HomeViewModelOutput {}

--- a/Example/XCoordinator/Scenes/Home/HomeViewModelImpl.swift
+++ b/Example/XCoordinator/Scenes/Home/HomeViewModelImpl.swift
@@ -14,8 +14,8 @@ class HomeViewModelImpl: HomeViewModel, HomeViewModelInput, HomeViewModelOutput 
 
     // MARK: - Inputs
 
-    private(set) lazy var logoutTrigger: InputSubject<Void> = logoutAction.inputs
-    private(set) lazy var usersTrigger: InputSubject<Void> = usersAction.inputs
+    private(set) lazy var logoutTrigger: AnyObserver<Void> = logoutAction.inputs
+    private(set) lazy var usersTrigger: AnyObserver<Void> = usersAction.inputs
 
     // MARK: - Actions
 

--- a/Example/XCoordinator/Scenes/Login/LoginViewModel.swift
+++ b/Example/XCoordinator/Scenes/Login/LoginViewModel.swift
@@ -11,7 +11,7 @@ import RxSwift
 import XCoordinator
 
 protocol LoginViewModelInput {
-    var loginTrigger: InputSubject<Void> { get }
+    var loginTrigger: AnyObserver<Void> { get }
 }
 
 protocol LoginViewModelOutput {}

--- a/Example/XCoordinator/Scenes/Login/LoginViewModelImpl.swift
+++ b/Example/XCoordinator/Scenes/Login/LoginViewModelImpl.swift
@@ -14,7 +14,7 @@ class LoginViewModelImpl: LoginViewModel, LoginViewModelInput, LoginViewModelOut
 
     // MARK: - Inputs
 
-    private(set) lazy var loginTrigger: InputSubject<Void> = loginAction.inputs
+    private(set) lazy var loginTrigger: AnyObserver<Void> = loginAction.inputs
 
     // MARK: - Actions
 

--- a/Example/XCoordinator/Scenes/News/NewsViewModel.swift
+++ b/Example/XCoordinator/Scenes/News/NewsViewModel.swift
@@ -10,7 +10,7 @@ import Action
 import RxSwift
 
 protocol NewsViewModelInput {
-    var selectedNews: InputSubject<News> { get }
+    var selectedNews: AnyObserver<News> { get }
 }
 
 protocol NewsViewModelOutput {

--- a/Example/XCoordinator/Scenes/User/UserViewModel.swift
+++ b/Example/XCoordinator/Scenes/User/UserViewModel.swift
@@ -11,8 +11,8 @@ import RxSwift
 import XCoordinator
 
 protocol UserViewModelInput {
-    var alertTrigger: InputSubject<Void> { get }
-    var closeTrigger: InputSubject<Void> { get }
+    var alertTrigger: AnyObserver<Void> { get }
+    var closeTrigger: AnyObserver<Void> { get }
 }
 
 protocol UserViewModelOutput {

--- a/Example/XCoordinator/Scenes/User/UserViewModelImpl.swift
+++ b/Example/XCoordinator/Scenes/User/UserViewModelImpl.swift
@@ -14,8 +14,8 @@ class UserViewModelImpl: UserViewModel, UserViewModelInput, UserViewModelOutput 
 
     // MARK: - Inputs
 
-    private(set) lazy var alertTrigger: InputSubject<Void> = alertAction.inputs
-    private(set) lazy var closeTrigger: InputSubject<Void> = closeAction.inputs
+    private(set) lazy var alertTrigger: AnyObserver<Void> = alertAction.inputs
+    private(set) lazy var closeTrigger: AnyObserver<Void> = closeAction.inputs
 
     // MARK: - Actions
 

--- a/Example/XCoordinator/Scenes/UserList/UsersViewModel.swift
+++ b/Example/XCoordinator/Scenes/UserList/UsersViewModel.swift
@@ -11,7 +11,7 @@ import RxSwift
 import XCoordinator
 
 protocol UsersViewModelInput {
-    var showUserTrigger: InputSubject<String> { get }
+    var showUserTrigger: AnyObserver<String> { get }
 }
 
 protocol UsersViewModelOutput {

--- a/Example/XCoordinator/Scenes/UserList/UsersViewModelImpl.swift
+++ b/Example/XCoordinator/Scenes/UserList/UsersViewModelImpl.swift
@@ -14,7 +14,7 @@ class UsersViewModelImpl: UsersViewModel, UsersViewModelInput, UsersViewModelOut
 
     // MARK: - Inputs
 
-    lazy var showUserTrigger: InputSubject<String> = showUserAction.inputs
+    lazy var showUserTrigger: AnyObserver<String> = showUserAction.inputs
 
     // MARK: - Actions
 

--- a/XCoordinator.podspec
+++ b/XCoordinator.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |spec|
 
     spec.subspec 'RxSwift' do |ss|
         ss.dependency 'XCoordinator/Core'
-        ss.dependency 'RxSwift', '~> 4.0'
+        ss.dependency 'RxSwift', '~> 5.0'
 
         ss.source_files = 'XCoordinator/Classes/RxSwift/*.swift'
     end


### PR DESCRIPTION
- Migrate to `RxSwift 5.0`
- Resolve all warning
- Updated Example with `Action 4.0`
- Update all conflicts with `InputSubject `