### PR TITLE
Add rootViewController to BaseCoordinator initializers

### DIFF
--- a/XCoordinator/Classes/BaseCoordinator.swift
+++ b/XCoordinator/Classes/BaseCoordinator.swift
@@ -40,8 +40,8 @@ open class BaseCoordinator<RouteType: Route, TransitionType: TransitionProtocol>
     /// - Parameter initialRoute:
     ///     If a route is specified, it is triggered before making the coordinator visible.
     ///
-    public init(initialRoute: RouteType?) {
-        rootViewControllerBox.set(generateRootViewController())
+    public init(rootViewController: RootViewController? = nil, initialRoute: RouteType?) {
+        rootViewControllerBox.set(rootViewController ?? generateRootViewController())
         initialRoute.map(prepareTransition).map(performTransitionAfterWindowAppeared)
     }
 
@@ -51,8 +51,8 @@ open class BaseCoordinator<RouteType: Route, TransitionType: TransitionProtocol>
     /// - Parameter initialTransition:
     ///     If a transition is specified, it is performed before making the coordinator visible.
     ///
-    public init(initialTransition: TransitionType?) {
-        rootViewControllerBox.set(generateRootViewController())
+    public init(rootViewController: RootViewController? = nil, initialTransition: TransitionType?) {
+        rootViewControllerBox.set(rootViewController ?? generateRootViewController())
         initialTransition.map(performTransitionAfterWindowAppeared)
     }
 

--- a/XCoordinator/Classes/NavigationCoordinator.swift
+++ b/XCoordinator/Classes/NavigationCoordinator.swift
@@ -43,8 +43,8 @@ open class NavigationCoordinator<RouteType: Route>: BaseCoordinator<RouteType, N
     /// - Parameter initialRoute:
     ///     The route to be triggered.
     ///
-    public override init(initialRoute: RouteType? = nil) {
-        super.init(initialRoute: initialRoute)
+    public override init(rootViewController: RootViewController? = nil, initialRoute: RouteType? = nil) {
+        super.init(rootViewController: rootViewController, initialRoute: initialRoute)
     }
 
     ///

--- a/XCoordinator/Classes/SplitCoordinator.swift
+++ b/XCoordinator/Classes/SplitCoordinator.swift
@@ -17,8 +17,8 @@ open class SplitCoordinator<RouteType: Route>: BaseCoordinator<RouteType, SplitT
 
     // MARK: - Initialization
 
-    public override init(initialRoute: RouteType?) {
-        super.init(initialRoute: initialRoute)
+    public override init(rootViewController: RootViewController? = nil, initialRoute: RouteType?) {
+        super.init(rootViewController: rootViewController, initialRoute: initialRoute)
     }
 
     ///

--- a/XCoordinator/Classes/TabBarCoordinator.swift
+++ b/XCoordinator/Classes/TabBarCoordinator.swift
@@ -38,8 +38,8 @@ open class TabBarCoordinator<RouteType: Route>: BaseCoordinator<RouteType, TabBa
 
     // MARK: - Initialization
 
-    public override init(initialRoute: RouteType?) {
-        super.init(initialRoute: initialRoute)
+    public override init(rootViewController: RootViewController? = nil, initialRoute: RouteType?) {
+        super.init(rootViewController: rootViewController, initialRoute: initialRoute)
     }
 
     ///

--- a/XCoordinator/Classes/ViewCoordinator.swift
+++ b/XCoordinator/Classes/ViewCoordinator.swift
@@ -18,8 +18,8 @@ open class ViewCoordinator<RouteType: Route>: BaseCoordinator<RouteType, ViewTra
 
     // MARK: - Initialization
 
-    public override init(initialRoute: RouteType?) {
-        super.init(initialRoute: initialRoute)
+    public override init(rootViewController: RootViewController? = nil, initialRoute: RouteType?) {
+        super.init(rootViewController: rootViewController, initialRoute: initialRoute)
     }
 
     ///


### PR DESCRIPTION
Planned for 2.0.0

Add the possibility to set the rootViewController right with the initializer. 
We might even want to remove the `generateRootViewController` method, but that would mean that we would set the delegate of the rootViewController (might override user choice) in TabBarCoordinator and NavigationCoordinator to get animations working...