### PR TITLE
Fix: Peek-Pop memory leaks in Example app

### DIFF
--- a/Example/XCoordinator/Coordinators/AppCoordinator.swift
+++ b/Example/XCoordinator/Coordinators/AppCoordinator.swift
@@ -40,12 +40,12 @@ class AppCoordinator: NavigationCoordinator<AppRoute> {
             viewController.bind(to: viewModel)
             return .push(viewController)
         case .home:
-            let presentables: [Presentable] = [
-                HomeTabCoordinator(),
-                HomeSplitCoordinator(),
-                HomePageCoordinator()
+            let presentables: [() -> Presentable] = [
+                { HomeTabCoordinator() },
+                { HomeSplitCoordinator() },
+                { HomePageCoordinator() }
             ]
-            let presentable = presentables[homeRouteTriggerCount % presentables.count]
+            let presentable = presentables[homeRouteTriggerCount % presentables.count]()
             homeRouteTriggerCount = (homeRouteTriggerCount + 1) % presentables.count
             self.home = presentable
             return .present(presentable, animation: .fade)

--- a/XCoordinator/Classes/CoordinatorPreviewingDelegateObject.swift
+++ b/XCoordinator/Classes/CoordinatorPreviewingDelegateObject.swift
@@ -16,7 +16,7 @@ NSObject, UIViewControllerPreviewingDelegate {
     private weak var viewController: UIViewController?
 
     private let transition: () -> TransitionType
-    private let rootViewController: TransitionType.RootViewController
+    private weak var rootViewController: TransitionType.RootViewController?
     private let completion: PresentationHandler?
 
     // MARK: - Initialization
@@ -46,6 +46,10 @@ NSObject, UIViewControllerPreviewingDelegate {
 
     internal func previewingContext(_ previewingContext: UIViewControllerPreviewing,
                                     commit viewControllerToCommit: UIViewController) {
+        guard let rootViewController = rootViewController else {
+            assertionFailure("The rootViewController is no longer available to perform this preview transition on.")
+            return
+        }
         transition().perform(on: rootViewController, with: .default, completion: completion)
     }
 }


### PR DESCRIPTION
Planned for 1.5.1/1.6.0 alongside https://github.com/quickbirdstudios/XCoordinator/pull/98.

This MR handles the memory leak mentioned by @Ricardo1980 in https://github.com/quickbirdstudios/XCoordinator/issues/104.