### PR TITLE
Fix: Support more presentation levels

### DIFF
--- a/XCoordinator/Classes/TransitionPerformer+Transition.swift
+++ b/XCoordinator/Classes/TransitionPerformer+Transition.swift
@@ -8,6 +8,10 @@
 
 extension UIViewController {
 
+    private var topPresentedViewController: UIViewController? {
+        return presentedViewController?.topPresentedViewController ?? presentedViewController
+    }
+
     func show(_ viewController: UIViewController,
               with options: TransitionOptions,
               completion: PresentationHandler?) {
@@ -43,7 +47,7 @@ extension UIViewController {
         }
         let presentingViewController = onRoot
             ? self
-            : (presentedViewController ?? self)
+            : (topPresentedViewController ?? self)
         presentingViewController.present(viewController, animated: options.animated, completion: completion)
     }
 
@@ -51,7 +55,7 @@ extension UIViewController {
                  with options: TransitionOptions,
                  animation: Animation?,
                  completion: PresentationHandler?) {
-        let presentedViewController = self.presentedViewController ?? self
+        let presentedViewController = topPresentedViewController ?? self
         if let animation = animation {
             presentedViewController.transitioningDelegate = animation
         }


### PR DESCRIPTION
Planned for 1.5.2.

As noted by @msebgf in https://github.com/quickbirdstudios/XCoordinator/issues/116, currently XCoordinator only allows to have 2 full-screen presentations on top of each other. 

This fix changes the behavior of the `.present` and `.dismiss` transitions to check for the topPresentedViewController (i.e. the top most viewController currently presented to the user) instead of only checking one hierarchy level.