### PR TITLE
Initial appearance transition

### DIFF
--- a/Sources/XCoordinator/BaseCoordinator.swift
+++ b/Sources/XCoordinator/BaseCoordinator.swift
@@ -121,12 +121,10 @@ open class BaseCoordinator<RouteType: Route, TransitionType: TransitionProtocol>
 
         var windowAppearanceObserver: Any?
 
-        rootViewController.beginAppearanceTransition(true, animated: false)
         windowAppearanceObserver = NotificationCenter.default.addObserver(
             forName: UIWindow.didBecomeKeyNotification, object: nil, queue: .main) { [weak self] _ in
             windowAppearanceObserver.map(NotificationCenter.default.removeObserver)
             windowAppearanceObserver = nil
-            self?.rootViewController.endAppearanceTransition()
             DispatchQueue.main.async {
                 self?.performTransition(transition, with: TransitionOptions(animated: false))
             }

--- a/XCoordinator.podspec
+++ b/XCoordinator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name         = 'XCoordinator'
-    spec.version      = '2.0.0'
+    spec.version      = '2.0.1'
     spec.license      = { :type => 'MIT' }
     spec.homepage     = 'https://github.com/quickbirdstudios/XCoordinator'
     spec.authors      = { 'Stefan Kofler' => 'stefan.kofler@quickbirdstudios.com', 'Paul Kraft' => 'pauljohannes.kraft@quickbirdstudios.com' }


### PR DESCRIPTION
Planned for 2.0.1.

Changelog:
- Remove calls to `UIViewController.beginAppearanceTransition` and `UIViewController.endAppearanceTransition` when performing the initial transition.