### PR TITLE
Use topPresentedViewController instead of presentedViewController in presentation transitions

### DIFF
--- a/Sources/XCoordinator/UIViewController+Transition.swift
+++ b/Sources/XCoordinator/UIViewController+Transition.swift
@@ -10,6 +10,10 @@ import UIKit
 
 extension UIViewController {
 
+    private var topPresentedViewController: UIViewController {
+        return presentedViewController?.topPresentedViewController ?? self
+    }
+
     func show(_ viewController: UIViewController,
               with options: TransitionOptions,
               completion: PresentationHandler?) {
@@ -49,7 +53,7 @@ extension UIViewController {
         }
         let presentingViewController = onRoot
             ? self
-            : (presentedViewController ?? self)
+            : topPresentedViewController
         presentingViewController.present(viewController, animated: options.animated, completion: completion)
     }
 
@@ -57,7 +61,7 @@ extension UIViewController {
                  with options: TransitionOptions,
                  animation: Animation?,
                  completion: PresentationHandler?) {
-        let presentedViewController = self.presentedViewController ?? self
+        let presentedViewController = topPresentedViewController
         if let animation = animation {
             presentedViewController.transitioningDelegate = animation
         }

--- a/XCoordinator.podspec
+++ b/XCoordinator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name         = 'XCoordinator'
-    spec.version      = '2.0.2'
+    spec.version      = '2.0.3'
     spec.license      = { :type => 'MIT' }
     spec.homepage     = 'https://github.com/quickbirdstudios/XCoordinator'
     spec.authors      = { 'Stefan Kofler' => 'stefan.kofler@quickbirdstudios.com', 'Paul Kraft' => 'pauljohannes.kraft@quickbirdstudios.com' }


### PR DESCRIPTION
Planned for 2.0.3.

Changelog:
- Use topPresentedViewController instead of presentedViewController in presentation transitions. This allows for more than 2 presentations in one coordinator at the same time.