### PR TITLE
Bugfix: PageCoordinator

### DIFF
--- a/Sources/XCoordinator/PageCoordinator.swift
+++ b/Sources/XCoordinator/PageCoordinator.swift
@@ -58,6 +58,7 @@ open class PageCoordinator<RouteType: Route>: BaseCoordinator<RouteType, PageTra
                 set: Presentable? = nil,
                 direction: UIPageViewController.NavigationDirection = .forward) {
         self.dataSource = PageCoordinatorDataSource(pages: pages.map { $0.viewController }, loop: loop)
+        rootViewController.dataSource = dataSource
 
         guard let firstPage = set ?? pages.first else {
             assertionFailure("Please provide a positive number of pages for use in \(String(describing: PageCoordinator<RouteType>.self))")

--- a/Sources/XCoordinator/PageCoordinator.swift
+++ b/Sources/XCoordinator/PageCoordinator.swift
@@ -61,7 +61,7 @@ open class PageCoordinator<RouteType: Route>: BaseCoordinator<RouteType, PageTra
 
         guard let firstPage = set ?? pages.first else {
             assertionFailure("Please provide a positive number of pages for use in \(String(describing: PageCoordinator<RouteType>.self))")
-            super.init(rootViewController: rootViewController, initialRoute: nil)
+            super.init(rootViewController: rootViewController, initialTransition: .initial(pages: pages))
             return
         }
 
@@ -93,7 +93,7 @@ open class PageCoordinator<RouteType: Route>: BaseCoordinator<RouteType, PageTra
                 set: Presentable,
                 direction: UIPageViewController.NavigationDirection) {
         self.dataSource = dataSource
-        
+        rootViewController.dataSource = dataSource
         super.init(rootViewController: rootViewController,
                    initialTransition: .set(set, direction: direction))
     }

--- a/XCoordinator.podspec
+++ b/XCoordinator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name         = 'XCoordinator'
-    spec.version      = '2.0.3'
+    spec.version      = '2.0.5'
     spec.license      = { :type => 'MIT' }
     spec.homepage     = 'https://github.com/quickbirdstudios/XCoordinator'
     spec.authors      = { 'Stefan Kofler' => 'stefan.kofler@quickbirdstudios.com', 'Paul Kraft' => 'pauljohannes.kraft@quickbirdstudios.com' }


### PR DESCRIPTION
Planned for 2.0.5.

Changelog: 
- PageCoordinator now actually sets its own dataSource to the rootViewController as intended.