### PR TITLE
NavigationAnimationDelegate to notify about NavigationCoordinator view hierarchy changes

### DIFF
--- a/Sources/XCoordinator/NavigationAnimationDelegate.swift
+++ b/Sources/XCoordinator/NavigationAnimationDelegate.swift
@@ -41,6 +41,7 @@ open class NavigationAnimationDelegate: NSObject {
     // MARK: Weak properties
 
     internal weak var delegate: UINavigationControllerDelegate?
+    internal weak var presentable: (Presentable & AnyObject)?
     private weak var navigationController: UINavigationController?
 
     // MARK: Helper methods
@@ -132,6 +133,7 @@ extension NavigationAnimationDelegate: UINavigationControllerDelegate {
     open func navigationController(_ navigationController: UINavigationController,
                                    didShow viewController: UIViewController, animated: Bool) {
         setupPopGestureRecognizer(for: navigationController)
+        presentable?.childTransitionCompleted()
         delegate?.navigationController?(navigationController, didShow: viewController, animated: animated)
     }
 

--- a/Sources/XCoordinator/NavigationCoordinator.swift
+++ b/Sources/XCoordinator/NavigationCoordinator.swift
@@ -57,6 +57,7 @@ open class NavigationCoordinator<RouteType: Route>: BaseCoordinator<RouteType, N
             rootViewController.delegate = animationDelegate
         }
         super.init(rootViewController: rootViewController, initialRoute: initialRoute)
+        animationDelegate.presentable = self
     }
 
     ///
@@ -70,6 +71,7 @@ open class NavigationCoordinator<RouteType: Route>: BaseCoordinator<RouteType, N
             rootViewController.delegate = animationDelegate
         }
         super.init(rootViewController: rootViewController, initialTransition: .push(root))
+        animationDelegate.presentable = self
     }
 
 }


### PR DESCRIPTION
Planned for 2.0.7

Changelog:
- NavigationAnimationDelegate now informs NavigationCoordinator about changes in the view hierarchy even when they were not initiated by XCoordinator.