### PR TITLE
Update RxSwift and add missing CURRENT_PROJECT_VERSION

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {
           "branch": null,
-          "revision": "b3e888b4972d9bc76495dd74d30a8c7fad4b9395",
-          "version": "5.0.1"
+          "revision": "002d325b0bdee94e7882e1114af5ff4fe1e96afa",
+          "version": "5.1.1"
         }
       }
     ]

--- a/XCoordinator.xcodeproj/RxSwift_Info.plist
+++ b/XCoordinator.xcodeproj/RxSwift_Info.plist
@@ -18,7 +18,7 @@
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>
-  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <string>1</string>
   <key>NSPrincipalClass</key>
   <string></string>
 </dict>

--- a/XCoordinator.xcodeproj/XCoordinatorCombine_Info.plist
+++ b/XCoordinator.xcodeproj/XCoordinatorCombine_Info.plist
@@ -18,7 +18,7 @@
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>
-  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <string>1</string>
   <key>NSPrincipalClass</key>
   <string></string>
 </dict>

--- a/XCoordinator.xcodeproj/XCoordinatorRx_Info.plist
+++ b/XCoordinator.xcodeproj/XCoordinatorRx_Info.plist
@@ -18,7 +18,7 @@
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>
-  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <string>1</string>
   <key>NSPrincipalClass</key>
   <string></string>
 </dict>

--- a/XCoordinator.xcodeproj/XCoordinatorTests_Info.plist
+++ b/XCoordinator.xcodeproj/XCoordinatorTests_Info.plist
@@ -18,7 +18,7 @@
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>
-  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <string>1</string>
   <key>NSPrincipalClass</key>
   <string></string>
 </dict>

--- a/XCoordinator.xcodeproj/XCoordinator_Info.plist
+++ b/XCoordinator.xcodeproj/XCoordinator_Info.plist
@@ -18,7 +18,7 @@
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>
-  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <string>1</string>
   <key>NSPrincipalClass</key>
   <string></string>
 </dict>

--- a/XCoordinator.xcodeproj/project.pbxproj
+++ b/XCoordinator.xcodeproj/project.pbxproj
@@ -1,1892 +1,3395 @@
 // !$*UTF8*$!
 {
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXAggregateTarget section */
-		"XCoordinator::XCoordinatorPackageTests::ProductTarget" /* XCoordinatorPackageTests */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = OBJ_469 /* Build configuration list for PBXAggregateTarget "XCoordinatorPackageTests" */;
-			buildPhases = (
-			);
-			dependencies = (
-				OBJ_472 /* PBXTargetDependency */,
-			);
-			name = XCoordinatorPackageTests;
-			productName = XCoordinatorPackageTests;
-		};
-/* End PBXAggregateTarget section */
-
-/* Begin PBXBuildFile section */
-		OBJ_244 /* AddRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_74 /* AddRef.swift */; };
-		OBJ_245 /* Amb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_75 /* Amb.swift */; };
-		OBJ_246 /* AnonymousDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_76 /* AnonymousDisposable.swift */; };
-		OBJ_247 /* AnonymousObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_77 /* AnonymousObserver.swift */; };
-		OBJ_248 /* AnyObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_78 /* AnyObserver.swift */; };
-		OBJ_249 /* AsMaybe.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_79 /* AsMaybe.swift */; };
-		OBJ_250 /* AsSingle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_80 /* AsSingle.swift */; };
-		OBJ_251 /* AsyncLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_81 /* AsyncLock.swift */; };
-		OBJ_252 /* AsyncSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_82 /* AsyncSubject.swift */; };
-		OBJ_253 /* AtomicInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_83 /* AtomicInt.swift */; };
-		OBJ_254 /* Bag+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_84 /* Bag+Rx.swift */; };
-		OBJ_255 /* Bag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_85 /* Bag.swift */; };
-		OBJ_256 /* BehaviorSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_86 /* BehaviorSubject.swift */; };
-		OBJ_257 /* BinaryDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_87 /* BinaryDisposable.swift */; };
-		OBJ_258 /* BooleanDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_88 /* BooleanDisposable.swift */; };
-		OBJ_259 /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_89 /* Buffer.swift */; };
-		OBJ_260 /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_90 /* Cancelable.swift */; };
-		OBJ_261 /* Catch.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_91 /* Catch.swift */; };
-		OBJ_262 /* CombineLatest+Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_92 /* CombineLatest+Collection.swift */; };
-		OBJ_263 /* CombineLatest+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_93 /* CombineLatest+arity.swift */; };
-		OBJ_264 /* CombineLatest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_94 /* CombineLatest.swift */; };
-		OBJ_265 /* CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_95 /* CompactMap.swift */; };
-		OBJ_266 /* Completable+AndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_96 /* Completable+AndThen.swift */; };
-		OBJ_267 /* Completable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_97 /* Completable.swift */; };
-		OBJ_268 /* CompositeDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_98 /* CompositeDisposable.swift */; };
-		OBJ_269 /* Concat.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_99 /* Concat.swift */; };
-		OBJ_270 /* ConcurrentDispatchQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_100 /* ConcurrentDispatchQueueScheduler.swift */; };
-		OBJ_271 /* ConcurrentMainScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_101 /* ConcurrentMainScheduler.swift */; };
-		OBJ_272 /* ConnectableObservableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_102 /* ConnectableObservableType.swift */; };
-		OBJ_273 /* Create.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_103 /* Create.swift */; };
-		OBJ_274 /* CurrentThreadScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_104 /* CurrentThreadScheduler.swift */; };
-		OBJ_275 /* Date+Dispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_105 /* Date+Dispatch.swift */; };
-		OBJ_276 /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_106 /* Debounce.swift */; };
-		OBJ_277 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_107 /* Debug.swift */; };
-		OBJ_278 /* DefaultIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_108 /* DefaultIfEmpty.swift */; };
-		OBJ_279 /* Deferred.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_109 /* Deferred.swift */; };
-		OBJ_280 /* Delay.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_110 /* Delay.swift */; };
-		OBJ_281 /* DelaySubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_111 /* DelaySubscription.swift */; };
-		OBJ_282 /* Dematerialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_112 /* Dematerialize.swift */; };
-		OBJ_283 /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_113 /* Deprecated.swift */; };
-		OBJ_284 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_114 /* DispatchQueue+Extensions.swift */; };
-		OBJ_285 /* DispatchQueueConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_115 /* DispatchQueueConfiguration.swift */; };
-		OBJ_286 /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_116 /* Disposable.swift */; };
-		OBJ_287 /* Disposables.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_117 /* Disposables.swift */; };
-		OBJ_288 /* DisposeBag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_118 /* DisposeBag.swift */; };
-		OBJ_289 /* DisposeBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_119 /* DisposeBase.swift */; };
-		OBJ_290 /* DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_120 /* DistinctUntilChanged.swift */; };
-		OBJ_291 /* Do.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_121 /* Do.swift */; };
-		OBJ_292 /* ElementAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_122 /* ElementAt.swift */; };
-		OBJ_293 /* Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_123 /* Empty.swift */; };
-		OBJ_294 /* Enumerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_124 /* Enumerated.swift */; };
-		OBJ_295 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_125 /* Error.swift */; };
-		OBJ_296 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_126 /* Errors.swift */; };
-		OBJ_297 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_127 /* Event.swift */; };
-		OBJ_298 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_128 /* Filter.swift */; };
-		OBJ_299 /* First.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_129 /* First.swift */; };
-		OBJ_300 /* Generate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_130 /* Generate.swift */; };
-		OBJ_301 /* GroupBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_131 /* GroupBy.swift */; };
-		OBJ_302 /* GroupedObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_132 /* GroupedObservable.swift */; };
-		OBJ_303 /* HistoricalScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_133 /* HistoricalScheduler.swift */; };
-		OBJ_304 /* HistoricalSchedulerTimeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_134 /* HistoricalSchedulerTimeConverter.swift */; };
-		OBJ_305 /* ImmediateSchedulerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_135 /* ImmediateSchedulerType.swift */; };
-		OBJ_306 /* InfiniteSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_136 /* InfiniteSequence.swift */; };
-		OBJ_307 /* InvocableScheduledItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_137 /* InvocableScheduledItem.swift */; };
-		OBJ_308 /* InvocableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_138 /* InvocableType.swift */; };
-		OBJ_309 /* Just.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_139 /* Just.swift */; };
-		OBJ_310 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_140 /* Lock.swift */; };
-		OBJ_311 /* LockOwnerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_141 /* LockOwnerType.swift */; };
-		OBJ_312 /* MainScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_142 /* MainScheduler.swift */; };
-		OBJ_313 /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_143 /* Map.swift */; };
-		OBJ_314 /* Materialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_144 /* Materialize.swift */; };
-		OBJ_315 /* Maybe.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_145 /* Maybe.swift */; };
-		OBJ_316 /* Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_146 /* Merge.swift */; };
-		OBJ_317 /* Multicast.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_147 /* Multicast.swift */; };
-		OBJ_318 /* Never.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_148 /* Never.swift */; };
-		OBJ_319 /* NopDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_149 /* NopDisposable.swift */; };
-		OBJ_320 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_150 /* Observable.swift */; };
-		OBJ_321 /* ObservableConvertibleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_151 /* ObservableConvertibleType.swift */; };
-		OBJ_322 /* ObservableType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_152 /* ObservableType+Extensions.swift */; };
-		OBJ_323 /* ObservableType+PrimitiveSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_153 /* ObservableType+PrimitiveSequence.swift */; };
-		OBJ_324 /* ObservableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_154 /* ObservableType.swift */; };
-		OBJ_325 /* ObserveOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_155 /* ObserveOn.swift */; };
-		OBJ_326 /* ObserverBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_156 /* ObserverBase.swift */; };
-		OBJ_327 /* ObserverType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_157 /* ObserverType.swift */; };
-		OBJ_328 /* OperationQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_158 /* OperationQueueScheduler.swift */; };
-		OBJ_329 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_159 /* Optional.swift */; };
-		OBJ_330 /* Platform.Darwin.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_160 /* Platform.Darwin.swift */; };
-		OBJ_331 /* Platform.Linux.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_161 /* Platform.Linux.swift */; };
-		OBJ_332 /* PrimitiveSequence+Zip+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_162 /* PrimitiveSequence+Zip+arity.swift */; };
-		OBJ_333 /* PrimitiveSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_163 /* PrimitiveSequence.swift */; };
-		OBJ_334 /* PriorityQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_164 /* PriorityQueue.swift */; };
-		OBJ_335 /* Producer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_165 /* Producer.swift */; };
-		OBJ_336 /* PublishSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_166 /* PublishSubject.swift */; };
-		OBJ_337 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_167 /* Queue.swift */; };
-		OBJ_338 /* Range.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_168 /* Range.swift */; };
-		OBJ_339 /* Reactive.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_169 /* Reactive.swift */; };
-		OBJ_340 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_170 /* RecursiveLock.swift */; };
-		OBJ_341 /* RecursiveScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_171 /* RecursiveScheduler.swift */; };
-		OBJ_342 /* Reduce.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_172 /* Reduce.swift */; };
-		OBJ_343 /* RefCountDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_173 /* RefCountDisposable.swift */; };
-		OBJ_344 /* Repeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_174 /* Repeat.swift */; };
-		OBJ_345 /* ReplaySubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_175 /* ReplaySubject.swift */; };
-		OBJ_346 /* RetryWhen.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_176 /* RetryWhen.swift */; };
-		OBJ_347 /* Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_177 /* Rx.swift */; };
-		OBJ_348 /* RxMutableBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_178 /* RxMutableBox.swift */; };
-		OBJ_349 /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_179 /* Sample.swift */; };
-		OBJ_350 /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_180 /* Scan.swift */; };
-		OBJ_351 /* ScheduledDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_181 /* ScheduledDisposable.swift */; };
-		OBJ_352 /* ScheduledItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_182 /* ScheduledItem.swift */; };
-		OBJ_353 /* ScheduledItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_183 /* ScheduledItemType.swift */; };
-		OBJ_354 /* SchedulerServices+Emulation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_184 /* SchedulerServices+Emulation.swift */; };
-		OBJ_355 /* SchedulerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_185 /* SchedulerType.swift */; };
-		OBJ_356 /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_186 /* Sequence.swift */; };
-		OBJ_357 /* SerialDispatchQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_187 /* SerialDispatchQueueScheduler.swift */; };
-		OBJ_358 /* SerialDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_188 /* SerialDisposable.swift */; };
-		OBJ_359 /* ShareReplayScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_189 /* ShareReplayScope.swift */; };
-		OBJ_360 /* Single.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_190 /* Single.swift */; };
-		OBJ_361 /* SingleAssignmentDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_191 /* SingleAssignmentDisposable.swift */; };
-		OBJ_362 /* SingleAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_192 /* SingleAsync.swift */; };
-		OBJ_363 /* Sink.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_193 /* Sink.swift */; };
-		OBJ_364 /* Skip.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_194 /* Skip.swift */; };
-		OBJ_365 /* SkipUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_195 /* SkipUntil.swift */; };
-		OBJ_366 /* SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_196 /* SkipWhile.swift */; };
-		OBJ_367 /* StartWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_197 /* StartWith.swift */; };
-		OBJ_368 /* String+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_198 /* String+Rx.swift */; };
-		OBJ_369 /* SubjectType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_199 /* SubjectType.swift */; };
-		OBJ_370 /* SubscribeOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_200 /* SubscribeOn.swift */; };
-		OBJ_371 /* SubscriptionDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_201 /* SubscriptionDisposable.swift */; };
-		OBJ_372 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_202 /* SwiftSupport.swift */; };
-		OBJ_373 /* Switch.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_203 /* Switch.swift */; };
-		OBJ_374 /* SwitchIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_204 /* SwitchIfEmpty.swift */; };
-		OBJ_375 /* SynchronizedDisposeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_205 /* SynchronizedDisposeType.swift */; };
-		OBJ_376 /* SynchronizedOnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_206 /* SynchronizedOnType.swift */; };
-		OBJ_377 /* SynchronizedUnsubscribeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_207 /* SynchronizedUnsubscribeType.swift */; };
-		OBJ_378 /* TailRecursiveSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_208 /* TailRecursiveSink.swift */; };
-		OBJ_379 /* Take.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_209 /* Take.swift */; };
-		OBJ_380 /* TakeLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_210 /* TakeLast.swift */; };
-		OBJ_381 /* TakeUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_211 /* TakeUntil.swift */; };
-		OBJ_382 /* TakeWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_212 /* TakeWhile.swift */; };
-		OBJ_383 /* Throttle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_213 /* Throttle.swift */; };
-		OBJ_384 /* Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_214 /* Timeout.swift */; };
-		OBJ_385 /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_215 /* Timer.swift */; };
-		OBJ_386 /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_216 /* ToArray.swift */; };
-		OBJ_387 /* Using.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_217 /* Using.swift */; };
-		OBJ_388 /* VirtualTimeConverterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_218 /* VirtualTimeConverterType.swift */; };
-		OBJ_389 /* VirtualTimeScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_219 /* VirtualTimeScheduler.swift */; };
-		OBJ_390 /* Window.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_220 /* Window.swift */; };
-		OBJ_391 /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_221 /* WithLatestFrom.swift */; };
-		OBJ_392 /* Zip+Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_222 /* Zip+Collection.swift */; };
-		OBJ_393 /* Zip+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_223 /* Zip+arity.swift */; };
-		OBJ_394 /* Zip.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_224 /* Zip.swift */; };
-		OBJ_401 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_226 /* Package.swift */; };
-		OBJ_407 /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* Animation.swift */; };
-		OBJ_408 /* AnyCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* AnyCoordinator.swift */; };
-		OBJ_409 /* AnyTransitionPerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* AnyTransitionPerformer.swift */; };
-		OBJ_410 /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* BaseCoordinator.swift */; };
-		OBJ_411 /* BasicCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* BasicCoordinator.swift */; };
-		OBJ_412 /* Container.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* Container.swift */; };
-		OBJ_413 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Coordinator.swift */; };
-		OBJ_414 /* CoordinatorPreviewingDelegateObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* CoordinatorPreviewingDelegateObject.swift */; };
-		OBJ_415 /* DeepLinking.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* DeepLinking.swift */; };
-		OBJ_416 /* GestureRecognizerTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* GestureRecognizerTarget.swift */; };
-		OBJ_417 /* InteractiveTransitionAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* InteractiveTransitionAnimation.swift */; };
-		OBJ_418 /* InterruptibleTransitionAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* InterruptibleTransitionAnimation.swift */; };
-		OBJ_419 /* NavigationAnimationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* NavigationAnimationDelegate.swift */; };
-		OBJ_420 /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* NavigationCoordinator.swift */; };
-		OBJ_421 /* NavigationTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* NavigationTransition.swift */; };
-		OBJ_422 /* PageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* PageCoordinator.swift */; };
-		OBJ_423 /* PageCoordinatorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* PageCoordinatorDataSource.swift */; };
-		OBJ_424 /* PageTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* PageTransition.swift */; };
-		OBJ_425 /* Presentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* Presentable.swift */; };
-		OBJ_426 /* RedirectionRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* RedirectionRouter.swift */; };
-		OBJ_427 /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* Route.swift */; };
-		OBJ_428 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_30 /* Router.swift */; };
-		OBJ_429 /* SplitCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* SplitCoordinator.swift */; };
-		OBJ_430 /* SplitTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_32 /* SplitTransition.swift */; };
-		OBJ_431 /* StaticTransitionAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* StaticTransitionAnimation.swift */; };
-		OBJ_432 /* StrongRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* StrongRouter.swift */; };
-		OBJ_433 /* TabBarAnimationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* TabBarAnimationDelegate.swift */; };
-		OBJ_434 /* TabBarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_36 /* TabBarCoordinator.swift */; };
-		OBJ_435 /* TabBarTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* TabBarTransition.swift */; };
-		OBJ_436 /* Transition+Init.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* Transition+Init.swift */; };
-		OBJ_437 /* Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* Transition.swift */; };
-		OBJ_438 /* TransitionAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_40 /* TransitionAnimation.swift */; };
-		OBJ_439 /* TransitionOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* TransitionOptions.swift */; };
-		OBJ_440 /* TransitionPerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_42 /* TransitionPerformer.swift */; };
-		OBJ_441 /* TransitionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_43 /* TransitionProtocol.swift */; };
-		OBJ_442 /* UINavigationController+Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_44 /* UINavigationController+Transition.swift */; };
-		OBJ_443 /* UIPageViewController+Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_45 /* UIPageViewController+Transition.swift */; };
-		OBJ_444 /* UITabBarController+Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_46 /* UITabBarController+Transition.swift */; };
-		OBJ_445 /* UIView+Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_47 /* UIView+Store.swift */; };
-		OBJ_446 /* UIViewController+Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_48 /* UIViewController+Transition.swift */; };
-		OBJ_447 /* UnownedErased+Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_49 /* UnownedErased+Router.swift */; };
-		OBJ_448 /* UnownedErased.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_50 /* UnownedErased.swift */; };
-		OBJ_449 /* ViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_51 /* ViewCoordinator.swift */; };
-		OBJ_450 /* WeakErased+Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_52 /* WeakErased+Router.swift */; };
-		OBJ_451 /* WeakErased.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_53 /* WeakErased.swift */; };
-		OBJ_458 /* Router+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_55 /* Router+Combine.swift */; };
-		OBJ_460 /* XCoordinator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XCoordinator::XCoordinator::Product" /* XCoordinator.framework */; };
-		OBJ_467 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
-		OBJ_479 /* Router+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_57 /* Router+Rx.swift */; };
-		OBJ_481 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "RxSwift::RxSwift::Product" /* RxSwift.framework */; };
-		OBJ_482 /* XCoordinator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XCoordinator::XCoordinator::Product" /* XCoordinator.framework */; };
-		OBJ_489 /* AnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_61 /* AnimationTests.swift */; };
-		OBJ_490 /* TestAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_62 /* TestAnimation.swift */; };
-		OBJ_491 /* TestRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_63 /* TestRoute.swift */; };
-		OBJ_492 /* TransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_64 /* TransitionTests.swift */; };
-		OBJ_493 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_65 /* XCTestManifests.swift */; };
-		OBJ_494 /* XCText+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_66 /* XCText+Extras.swift */; };
-		OBJ_496 /* XCoordinatorRx.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XCoordinator::XCoordinatorRx::Product" /* XCoordinatorRx.framework */; };
-		OBJ_497 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "RxSwift::RxSwift::Product" /* RxSwift.framework */; };
-		OBJ_498 /* XCoordinator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XCoordinator::XCoordinator::Product" /* XCoordinator.framework */; };
-/* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		9BC82EB7233D8CD000C604A8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "RxSwift::RxSwift";
-			remoteInfo = RxSwift;
-		};
-		9BC82EB8233D8CD000C604A8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "XCoordinator::XCoordinator";
-			remoteInfo = XCoordinator;
-		};
-		9BC82EB9233D8CD000C604A8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "XCoordinator::XCoordinator";
-			remoteInfo = XCoordinator;
-		};
-		9BC82EBA233D8CD100C604A8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "XCoordinator::XCoordinatorRx";
-			remoteInfo = XCoordinatorRx;
-		};
-		9BC82EBB233D8CD100C604A8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "RxSwift::RxSwift";
-			remoteInfo = RxSwift;
-		};
-		9BC82EBC233D8CD100C604A8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "XCoordinator::XCoordinator";
-			remoteInfo = XCoordinator;
-		};
-		9BC82EBD233D8CD100C604A8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "XCoordinator::XCoordinatorTests";
-			remoteInfo = XCoordinatorTests;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXFileReference section */
-		OBJ_10 /* AnyCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCoordinator.swift; sourceTree = "<group>"; };
-		OBJ_100 /* ConcurrentDispatchQueueScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcurrentDispatchQueueScheduler.swift; sourceTree = "<group>"; };
-		OBJ_101 /* ConcurrentMainScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcurrentMainScheduler.swift; sourceTree = "<group>"; };
-		OBJ_102 /* ConnectableObservableType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectableObservableType.swift; sourceTree = "<group>"; };
-		OBJ_103 /* Create.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Create.swift; sourceTree = "<group>"; };
-		OBJ_104 /* CurrentThreadScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentThreadScheduler.swift; sourceTree = "<group>"; };
-		OBJ_105 /* Date+Dispatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Dispatch.swift"; sourceTree = "<group>"; };
-		OBJ_106 /* Debounce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debounce.swift; sourceTree = "<group>"; };
-		OBJ_107 /* Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug.swift; sourceTree = "<group>"; };
-		OBJ_108 /* DefaultIfEmpty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultIfEmpty.swift; sourceTree = "<group>"; };
-		OBJ_109 /* Deferred.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deferred.swift; sourceTree = "<group>"; };
-		OBJ_11 /* AnyTransitionPerformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyTransitionPerformer.swift; sourceTree = "<group>"; };
-		OBJ_110 /* Delay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Delay.swift; sourceTree = "<group>"; };
-		OBJ_111 /* DelaySubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelaySubscription.swift; sourceTree = "<group>"; };
-		OBJ_112 /* Dematerialize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dematerialize.swift; sourceTree = "<group>"; };
-		OBJ_113 /* Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecated.swift; sourceTree = "<group>"; };
-		OBJ_114 /* DispatchQueue+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_115 /* DispatchQueueConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueConfiguration.swift; sourceTree = "<group>"; };
-		OBJ_116 /* Disposable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Disposable.swift; sourceTree = "<group>"; };
-		OBJ_117 /* Disposables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Disposables.swift; sourceTree = "<group>"; };
-		OBJ_118 /* DisposeBag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposeBag.swift; sourceTree = "<group>"; };
-		OBJ_119 /* DisposeBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposeBase.swift; sourceTree = "<group>"; };
-		OBJ_12 /* BaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCoordinator.swift; sourceTree = "<group>"; };
-		OBJ_120 /* DistinctUntilChanged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistinctUntilChanged.swift; sourceTree = "<group>"; };
-		OBJ_121 /* Do.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Do.swift; sourceTree = "<group>"; };
-		OBJ_122 /* ElementAt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementAt.swift; sourceTree = "<group>"; };
-		OBJ_123 /* Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Empty.swift; sourceTree = "<group>"; };
-		OBJ_124 /* Enumerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enumerated.swift; sourceTree = "<group>"; };
-		OBJ_125 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
-		OBJ_126 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
-		OBJ_127 /* Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
-		OBJ_128 /* Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
-		OBJ_129 /* First.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = First.swift; sourceTree = "<group>"; };
-		OBJ_13 /* BasicCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicCoordinator.swift; sourceTree = "<group>"; };
-		OBJ_130 /* Generate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Generate.swift; sourceTree = "<group>"; };
-		OBJ_131 /* GroupBy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupBy.swift; sourceTree = "<group>"; };
-		OBJ_132 /* GroupedObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedObservable.swift; sourceTree = "<group>"; };
-		OBJ_133 /* HistoricalScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalScheduler.swift; sourceTree = "<group>"; };
-		OBJ_134 /* HistoricalSchedulerTimeConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalSchedulerTimeConverter.swift; sourceTree = "<group>"; };
-		OBJ_135 /* ImmediateSchedulerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImmediateSchedulerType.swift; sourceTree = "<group>"; };
-		OBJ_136 /* InfiniteSequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteSequence.swift; sourceTree = "<group>"; };
-		OBJ_137 /* InvocableScheduledItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocableScheduledItem.swift; sourceTree = "<group>"; };
-		OBJ_138 /* InvocableType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocableType.swift; sourceTree = "<group>"; };
-		OBJ_139 /* Just.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Just.swift; sourceTree = "<group>"; };
-		OBJ_14 /* Container.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Container.swift; sourceTree = "<group>"; };
-		OBJ_140 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
-		OBJ_141 /* LockOwnerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockOwnerType.swift; sourceTree = "<group>"; };
-		OBJ_142 /* MainScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainScheduler.swift; sourceTree = "<group>"; };
-		OBJ_143 /* Map.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Map.swift; sourceTree = "<group>"; };
-		OBJ_144 /* Materialize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Materialize.swift; sourceTree = "<group>"; };
-		OBJ_145 /* Maybe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Maybe.swift; sourceTree = "<group>"; };
-		OBJ_146 /* Merge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Merge.swift; sourceTree = "<group>"; };
-		OBJ_147 /* Multicast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Multicast.swift; sourceTree = "<group>"; };
-		OBJ_148 /* Never.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Never.swift; sourceTree = "<group>"; };
-		OBJ_149 /* NopDisposable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NopDisposable.swift; sourceTree = "<group>"; };
-		OBJ_15 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
-		OBJ_150 /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
-		OBJ_151 /* ObservableConvertibleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableConvertibleType.swift; sourceTree = "<group>"; };
-		OBJ_152 /* ObservableType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ObservableType+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_153 /* ObservableType+PrimitiveSequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ObservableType+PrimitiveSequence.swift"; sourceTree = "<group>"; };
-		OBJ_154 /* ObservableType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableType.swift; sourceTree = "<group>"; };
-		OBJ_155 /* ObserveOn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserveOn.swift; sourceTree = "<group>"; };
-		OBJ_156 /* ObserverBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserverBase.swift; sourceTree = "<group>"; };
-		OBJ_157 /* ObserverType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserverType.swift; sourceTree = "<group>"; };
-		OBJ_158 /* OperationQueueScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationQueueScheduler.swift; sourceTree = "<group>"; };
-		OBJ_159 /* Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
-		OBJ_16 /* CoordinatorPreviewingDelegateObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorPreviewingDelegateObject.swift; sourceTree = "<group>"; };
-		OBJ_160 /* Platform.Darwin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Platform.Darwin.swift; sourceTree = "<group>"; };
-		OBJ_161 /* Platform.Linux.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Platform.Linux.swift; sourceTree = "<group>"; };
-		OBJ_162 /* PrimitiveSequence+Zip+arity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrimitiveSequence+Zip+arity.swift"; sourceTree = "<group>"; };
-		OBJ_163 /* PrimitiveSequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimitiveSequence.swift; sourceTree = "<group>"; };
-		OBJ_164 /* PriorityQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriorityQueue.swift; sourceTree = "<group>"; };
-		OBJ_165 /* Producer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Producer.swift; sourceTree = "<group>"; };
-		OBJ_166 /* PublishSubject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishSubject.swift; sourceTree = "<group>"; };
-		OBJ_167 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
-		OBJ_168 /* Range.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Range.swift; sourceTree = "<group>"; };
-		OBJ_169 /* Reactive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reactive.swift; sourceTree = "<group>"; };
-		OBJ_17 /* DeepLinking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinking.swift; sourceTree = "<group>"; };
-		OBJ_170 /* RecursiveLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecursiveLock.swift; sourceTree = "<group>"; };
-		OBJ_171 /* RecursiveScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecursiveScheduler.swift; sourceTree = "<group>"; };
-		OBJ_172 /* Reduce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reduce.swift; sourceTree = "<group>"; };
-		OBJ_173 /* RefCountDisposable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefCountDisposable.swift; sourceTree = "<group>"; };
-		OBJ_174 /* Repeat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repeat.swift; sourceTree = "<group>"; };
-		OBJ_175 /* ReplaySubject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaySubject.swift; sourceTree = "<group>"; };
-		OBJ_176 /* RetryWhen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryWhen.swift; sourceTree = "<group>"; };
-		OBJ_177 /* Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rx.swift; sourceTree = "<group>"; };
-		OBJ_178 /* RxMutableBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxMutableBox.swift; sourceTree = "<group>"; };
-		OBJ_179 /* Sample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sample.swift; sourceTree = "<group>"; };
-		OBJ_18 /* GestureRecognizerTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GestureRecognizerTarget.swift; sourceTree = "<group>"; };
-		OBJ_180 /* Scan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scan.swift; sourceTree = "<group>"; };
-		OBJ_181 /* ScheduledDisposable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledDisposable.swift; sourceTree = "<group>"; };
-		OBJ_182 /* ScheduledItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledItem.swift; sourceTree = "<group>"; };
-		OBJ_183 /* ScheduledItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledItemType.swift; sourceTree = "<group>"; };
-		OBJ_184 /* SchedulerServices+Emulation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SchedulerServices+Emulation.swift"; sourceTree = "<group>"; };
-		OBJ_185 /* SchedulerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulerType.swift; sourceTree = "<group>"; };
-		OBJ_186 /* Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sequence.swift; sourceTree = "<group>"; };
-		OBJ_187 /* SerialDispatchQueueScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerialDispatchQueueScheduler.swift; sourceTree = "<group>"; };
-		OBJ_188 /* SerialDisposable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerialDisposable.swift; sourceTree = "<group>"; };
-		OBJ_189 /* ShareReplayScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareReplayScope.swift; sourceTree = "<group>"; };
-		OBJ_19 /* InteractiveTransitionAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveTransitionAnimation.swift; sourceTree = "<group>"; };
-		OBJ_190 /* Single.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Single.swift; sourceTree = "<group>"; };
-		OBJ_191 /* SingleAssignmentDisposable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleAssignmentDisposable.swift; sourceTree = "<group>"; };
-		OBJ_192 /* SingleAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleAsync.swift; sourceTree = "<group>"; };
-		OBJ_193 /* Sink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sink.swift; sourceTree = "<group>"; };
-		OBJ_194 /* Skip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Skip.swift; sourceTree = "<group>"; };
-		OBJ_195 /* SkipUntil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkipUntil.swift; sourceTree = "<group>"; };
-		OBJ_196 /* SkipWhile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkipWhile.swift; sourceTree = "<group>"; };
-		OBJ_197 /* StartWith.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartWith.swift; sourceTree = "<group>"; };
-		OBJ_198 /* String+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Rx.swift"; sourceTree = "<group>"; };
-		OBJ_199 /* SubjectType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubjectType.swift; sourceTree = "<group>"; };
-		OBJ_20 /* InterruptibleTransitionAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterruptibleTransitionAnimation.swift; sourceTree = "<group>"; };
-		OBJ_200 /* SubscribeOn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscribeOn.swift; sourceTree = "<group>"; };
-		OBJ_201 /* SubscriptionDisposable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionDisposable.swift; sourceTree = "<group>"; };
-		OBJ_202 /* SwiftSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
-		OBJ_203 /* Switch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Switch.swift; sourceTree = "<group>"; };
-		OBJ_204 /* SwitchIfEmpty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchIfEmpty.swift; sourceTree = "<group>"; };
-		OBJ_205 /* SynchronizedDisposeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedDisposeType.swift; sourceTree = "<group>"; };
-		OBJ_206 /* SynchronizedOnType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedOnType.swift; sourceTree = "<group>"; };
-		OBJ_207 /* SynchronizedUnsubscribeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedUnsubscribeType.swift; sourceTree = "<group>"; };
-		OBJ_208 /* TailRecursiveSink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TailRecursiveSink.swift; sourceTree = "<group>"; };
-		OBJ_209 /* Take.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Take.swift; sourceTree = "<group>"; };
-		OBJ_21 /* NavigationAnimationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationAnimationDelegate.swift; sourceTree = "<group>"; };
-		OBJ_210 /* TakeLast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeLast.swift; sourceTree = "<group>"; };
-		OBJ_211 /* TakeUntil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeUntil.swift; sourceTree = "<group>"; };
-		OBJ_212 /* TakeWhile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeWhile.swift; sourceTree = "<group>"; };
-		OBJ_213 /* Throttle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Throttle.swift; sourceTree = "<group>"; };
-		OBJ_214 /* Timeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timeout.swift; sourceTree = "<group>"; };
-		OBJ_215 /* Timer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timer.swift; sourceTree = "<group>"; };
-		OBJ_216 /* ToArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToArray.swift; sourceTree = "<group>"; };
-		OBJ_217 /* Using.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Using.swift; sourceTree = "<group>"; };
-		OBJ_218 /* VirtualTimeConverterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualTimeConverterType.swift; sourceTree = "<group>"; };
-		OBJ_219 /* VirtualTimeScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualTimeScheduler.swift; sourceTree = "<group>"; };
-		OBJ_22 /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
-		OBJ_220 /* Window.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Window.swift; sourceTree = "<group>"; };
-		OBJ_221 /* WithLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithLatestFrom.swift; sourceTree = "<group>"; };
-		OBJ_222 /* Zip+Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Zip+Collection.swift"; sourceTree = "<group>"; };
-		OBJ_223 /* Zip+arity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Zip+arity.swift"; sourceTree = "<group>"; };
-		OBJ_224 /* Zip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Zip.swift; sourceTree = "<group>"; };
-		OBJ_226 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/pauljohanneskraft/Documents/QuickBirdStudios/Frameworks/XCoordinator/.build/checkouts/RxSwift/Package.swift; sourceTree = "<group>"; };
-		OBJ_23 /* NavigationTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTransition.swift; sourceTree = "<group>"; };
-		OBJ_233 /* Images */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Images; sourceTree = SOURCE_ROOT; };
-		OBJ_234 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; path = docs; sourceTree = SOURCE_ROOT; };
-		OBJ_235 /* scripts */ = {isa = PBXFileReference; lastKnownFileType = folder; path = scripts; sourceTree = SOURCE_ROOT; };
-		OBJ_236 /* XCoordinator.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = XCoordinator.podspec; sourceTree = "<group>"; };
-		OBJ_237 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
-		OBJ_238 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		OBJ_24 /* PageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageCoordinator.swift; sourceTree = "<group>"; };
-		OBJ_25 /* PageCoordinatorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageCoordinatorDataSource.swift; sourceTree = "<group>"; };
-		OBJ_26 /* PageTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTransition.swift; sourceTree = "<group>"; };
-		OBJ_27 /* Presentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presentable.swift; sourceTree = "<group>"; };
-		OBJ_28 /* RedirectionRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedirectionRouter.swift; sourceTree = "<group>"; };
-		OBJ_29 /* Route.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
-		OBJ_30 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
-		OBJ_31 /* SplitCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitCoordinator.swift; sourceTree = "<group>"; };
-		OBJ_32 /* SplitTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitTransition.swift; sourceTree = "<group>"; };
-		OBJ_33 /* StaticTransitionAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticTransitionAnimation.swift; sourceTree = "<group>"; };
-		OBJ_34 /* StrongRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrongRouter.swift; sourceTree = "<group>"; };
-		OBJ_35 /* TabBarAnimationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarAnimationDelegate.swift; sourceTree = "<group>"; };
-		OBJ_36 /* TabBarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarCoordinator.swift; sourceTree = "<group>"; };
-		OBJ_37 /* TabBarTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarTransition.swift; sourceTree = "<group>"; };
-		OBJ_38 /* Transition+Init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Transition+Init.swift"; sourceTree = "<group>"; };
-		OBJ_39 /* Transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transition.swift; sourceTree = "<group>"; };
-		OBJ_40 /* TransitionAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitionAnimation.swift; sourceTree = "<group>"; };
-		OBJ_41 /* TransitionOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitionOptions.swift; sourceTree = "<group>"; };
-		OBJ_42 /* TransitionPerformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitionPerformer.swift; sourceTree = "<group>"; };
-		OBJ_43 /* TransitionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitionProtocol.swift; sourceTree = "<group>"; };
-		OBJ_44 /* UINavigationController+Transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Transition.swift"; sourceTree = "<group>"; };
-		OBJ_45 /* UIPageViewController+Transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIPageViewController+Transition.swift"; sourceTree = "<group>"; };
-		OBJ_46 /* UITabBarController+Transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Transition.swift"; sourceTree = "<group>"; };
-		OBJ_47 /* UIView+Store.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Store.swift"; sourceTree = "<group>"; };
-		OBJ_48 /* UIViewController+Transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Transition.swift"; sourceTree = "<group>"; };
-		OBJ_49 /* UnownedErased+Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnownedErased+Router.swift"; sourceTree = "<group>"; };
-		OBJ_50 /* UnownedErased.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnownedErased.swift; sourceTree = "<group>"; };
-		OBJ_51 /* ViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewCoordinator.swift; sourceTree = "<group>"; };
-		OBJ_52 /* WeakErased+Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WeakErased+Router.swift"; sourceTree = "<group>"; };
-		OBJ_53 /* WeakErased.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakErased.swift; sourceTree = "<group>"; };
-		OBJ_55 /* Router+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Router+Combine.swift"; sourceTree = "<group>"; };
-		OBJ_57 /* Router+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Router+Rx.swift"; sourceTree = "<group>"; };
-		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
-		OBJ_60 /* XCoordinatorTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = XCoordinatorTests.xctestplan; sourceTree = "<group>"; };
-		OBJ_61 /* AnimationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationTests.swift; sourceTree = "<group>"; };
-		OBJ_62 /* TestAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAnimation.swift; sourceTree = "<group>"; };
-		OBJ_63 /* TestRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestRoute.swift; sourceTree = "<group>"; };
-		OBJ_64 /* TransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitionTests.swift; sourceTree = "<group>"; };
-		OBJ_65 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
-		OBJ_66 /* XCText+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCText+Extras.swift"; sourceTree = "<group>"; };
-		OBJ_74 /* AddRef.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRef.swift; sourceTree = "<group>"; };
-		OBJ_75 /* Amb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Amb.swift; sourceTree = "<group>"; };
-		OBJ_76 /* AnonymousDisposable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousDisposable.swift; sourceTree = "<group>"; };
-		OBJ_77 /* AnonymousObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousObserver.swift; sourceTree = "<group>"; };
-		OBJ_78 /* AnyObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyObserver.swift; sourceTree = "<group>"; };
-		OBJ_79 /* AsMaybe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsMaybe.swift; sourceTree = "<group>"; };
-		OBJ_80 /* AsSingle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsSingle.swift; sourceTree = "<group>"; };
-		OBJ_81 /* AsyncLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncLock.swift; sourceTree = "<group>"; };
-		OBJ_82 /* AsyncSubject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncSubject.swift; sourceTree = "<group>"; };
-		OBJ_83 /* AtomicInt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicInt.swift; sourceTree = "<group>"; };
-		OBJ_84 /* Bag+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bag+Rx.swift"; sourceTree = "<group>"; };
-		OBJ_85 /* Bag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bag.swift; sourceTree = "<group>"; };
-		OBJ_86 /* BehaviorSubject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorSubject.swift; sourceTree = "<group>"; };
-		OBJ_87 /* BinaryDisposable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryDisposable.swift; sourceTree = "<group>"; };
-		OBJ_88 /* BooleanDisposable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooleanDisposable.swift; sourceTree = "<group>"; };
-		OBJ_89 /* Buffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Buffer.swift; sourceTree = "<group>"; };
-		OBJ_9 /* Animation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animation.swift; sourceTree = "<group>"; };
-		OBJ_90 /* Cancelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancelable.swift; sourceTree = "<group>"; };
-		OBJ_91 /* Catch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Catch.swift; sourceTree = "<group>"; };
-		OBJ_92 /* CombineLatest+Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CombineLatest+Collection.swift"; sourceTree = "<group>"; };
-		OBJ_93 /* CombineLatest+arity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CombineLatest+arity.swift"; sourceTree = "<group>"; };
-		OBJ_94 /* CombineLatest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineLatest.swift; sourceTree = "<group>"; };
-		OBJ_95 /* CompactMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompactMap.swift; sourceTree = "<group>"; };
-		OBJ_96 /* Completable+AndThen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Completable+AndThen.swift"; sourceTree = "<group>"; };
-		OBJ_97 /* Completable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Completable.swift; sourceTree = "<group>"; };
-		OBJ_98 /* CompositeDisposable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeDisposable.swift; sourceTree = "<group>"; };
-		OBJ_99 /* Concat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Concat.swift; sourceTree = "<group>"; };
-		"RxSwift::RxSwift::Product" /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"XCoordinator::XCoordinator::Product" /* XCoordinator.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = XCoordinator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"XCoordinator::XCoordinatorCombine::Product" /* XCoordinatorCombine.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = XCoordinatorCombine.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"XCoordinator::XCoordinatorRx::Product" /* XCoordinatorRx.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = XCoordinatorRx.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"XCoordinator::XCoordinatorTests::Product" /* XCoordinatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = XCoordinatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		OBJ_395 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_452 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_459 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_460 /* XCoordinator.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_480 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_481 /* RxSwift.framework in Frameworks */,
-				OBJ_482 /* XCoordinator.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_495 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_496 /* XCoordinatorRx.framework in Frameworks */,
-				OBJ_497 /* RxSwift.framework in Frameworks */,
-				OBJ_498 /* XCoordinator.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		OBJ_225 /* RxTest */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = RxTest;
-			path = .build/checkouts/RxSwift/Sources/RxTest;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_227 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				"XCoordinator::XCoordinator::Product" /* XCoordinator.framework */,
-				"XCoordinator::XCoordinatorRx::Product" /* XCoordinatorRx.framework */,
-				"RxSwift::RxSwift::Product" /* RxSwift.framework */,
-				"XCoordinator::XCoordinatorCombine::Product" /* XCoordinatorCombine.framework */,
-				"XCoordinator::XCoordinatorTests::Product" /* XCoordinatorTests.xctest */,
-			);
-			name = Products;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		OBJ_5 = {
-			isa = PBXGroup;
-			children = (
-				OBJ_6 /* Package.swift */,
-				OBJ_7 /* Sources */,
-				OBJ_58 /* Tests */,
-				OBJ_67 /* Dependencies */,
-				OBJ_227 /* Products */,
-				OBJ_233 /* Images */,
-				OBJ_234 /* docs */,
-				OBJ_235 /* scripts */,
-				OBJ_236 /* XCoordinator.podspec */,
-				OBJ_237 /* LICENSE */,
-				OBJ_238 /* README.md */,
-			);
-			sourceTree = "<group>";
-		};
-		OBJ_54 /* XCoordinatorCombine */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_55 /* Router+Combine.swift */,
-			);
-			name = XCoordinatorCombine;
-			path = Sources/XCoordinatorCombine;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_56 /* XCoordinatorRx */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_57 /* Router+Rx.swift */,
-			);
-			name = XCoordinatorRx;
-			path = Sources/XCoordinatorRx;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_58 /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_59 /* XCoordinatorTests */,
-			);
-			name = Tests;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_59 /* XCoordinatorTests */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_60 /* XCoordinatorTests.xctestplan */,
-				OBJ_61 /* AnimationTests.swift */,
-				OBJ_62 /* TestAnimation.swift */,
-				OBJ_63 /* TestRoute.swift */,
-				OBJ_64 /* TransitionTests.swift */,
-				OBJ_65 /* XCTestManifests.swift */,
-				OBJ_66 /* XCText+Extras.swift */,
-			);
-			name = XCoordinatorTests;
-			path = Tests/XCoordinatorTests;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_67 /* Dependencies */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_68 /* RxSwift 5.0.1 */,
-			);
-			name = Dependencies;
-			sourceTree = "<group>";
-		};
-		OBJ_68 /* RxSwift 5.0.1 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_69 /* RxBlocking */,
-				OBJ_70 /* RxCocoa */,
-				OBJ_71 /* RxCocoaRuntime */,
-				OBJ_72 /* RxRelay */,
-				OBJ_73 /* RxSwift */,
-				OBJ_225 /* RxTest */,
-				OBJ_226 /* Package.swift */,
-			);
-			name = "RxSwift 5.0.1";
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_69 /* RxBlocking */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = RxBlocking;
-			path = .build/checkouts/RxSwift/Sources/RxBlocking;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_7 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_8 /* XCoordinator */,
-				OBJ_54 /* XCoordinatorCombine */,
-				OBJ_56 /* XCoordinatorRx */,
-			);
-			name = Sources;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_70 /* RxCocoa */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = RxCocoa;
-			path = .build/checkouts/RxSwift/Sources/RxCocoa;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_71 /* RxCocoaRuntime */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = RxCocoaRuntime;
-			path = .build/checkouts/RxSwift/Sources/RxCocoaRuntime;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_72 /* RxRelay */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = RxRelay;
-			path = .build/checkouts/RxSwift/Sources/RxRelay;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_73 /* RxSwift */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_74 /* AddRef.swift */,
-				OBJ_75 /* Amb.swift */,
-				OBJ_76 /* AnonymousDisposable.swift */,
-				OBJ_77 /* AnonymousObserver.swift */,
-				OBJ_78 /* AnyObserver.swift */,
-				OBJ_79 /* AsMaybe.swift */,
-				OBJ_80 /* AsSingle.swift */,
-				OBJ_81 /* AsyncLock.swift */,
-				OBJ_82 /* AsyncSubject.swift */,
-				OBJ_83 /* AtomicInt.swift */,
-				OBJ_84 /* Bag+Rx.swift */,
-				OBJ_85 /* Bag.swift */,
-				OBJ_86 /* BehaviorSubject.swift */,
-				OBJ_87 /* BinaryDisposable.swift */,
-				OBJ_88 /* BooleanDisposable.swift */,
-				OBJ_89 /* Buffer.swift */,
-				OBJ_90 /* Cancelable.swift */,
-				OBJ_91 /* Catch.swift */,
-				OBJ_92 /* CombineLatest+Collection.swift */,
-				OBJ_93 /* CombineLatest+arity.swift */,
-				OBJ_94 /* CombineLatest.swift */,
-				OBJ_95 /* CompactMap.swift */,
-				OBJ_96 /* Completable+AndThen.swift */,
-				OBJ_97 /* Completable.swift */,
-				OBJ_98 /* CompositeDisposable.swift */,
-				OBJ_99 /* Concat.swift */,
-				OBJ_100 /* ConcurrentDispatchQueueScheduler.swift */,
-				OBJ_101 /* ConcurrentMainScheduler.swift */,
-				OBJ_102 /* ConnectableObservableType.swift */,
-				OBJ_103 /* Create.swift */,
-				OBJ_104 /* CurrentThreadScheduler.swift */,
-				OBJ_105 /* Date+Dispatch.swift */,
-				OBJ_106 /* Debounce.swift */,
-				OBJ_107 /* Debug.swift */,
-				OBJ_108 /* DefaultIfEmpty.swift */,
-				OBJ_109 /* Deferred.swift */,
-				OBJ_110 /* Delay.swift */,
-				OBJ_111 /* DelaySubscription.swift */,
-				OBJ_112 /* Dematerialize.swift */,
-				OBJ_113 /* Deprecated.swift */,
-				OBJ_114 /* DispatchQueue+Extensions.swift */,
-				OBJ_115 /* DispatchQueueConfiguration.swift */,
-				OBJ_116 /* Disposable.swift */,
-				OBJ_117 /* Disposables.swift */,
-				OBJ_118 /* DisposeBag.swift */,
-				OBJ_119 /* DisposeBase.swift */,
-				OBJ_120 /* DistinctUntilChanged.swift */,
-				OBJ_121 /* Do.swift */,
-				OBJ_122 /* ElementAt.swift */,
-				OBJ_123 /* Empty.swift */,
-				OBJ_124 /* Enumerated.swift */,
-				OBJ_125 /* Error.swift */,
-				OBJ_126 /* Errors.swift */,
-				OBJ_127 /* Event.swift */,
-				OBJ_128 /* Filter.swift */,
-				OBJ_129 /* First.swift */,
-				OBJ_130 /* Generate.swift */,
-				OBJ_131 /* GroupBy.swift */,
-				OBJ_132 /* GroupedObservable.swift */,
-				OBJ_133 /* HistoricalScheduler.swift */,
-				OBJ_134 /* HistoricalSchedulerTimeConverter.swift */,
-				OBJ_135 /* ImmediateSchedulerType.swift */,
-				OBJ_136 /* InfiniteSequence.swift */,
-				OBJ_137 /* InvocableScheduledItem.swift */,
-				OBJ_138 /* InvocableType.swift */,
-				OBJ_139 /* Just.swift */,
-				OBJ_140 /* Lock.swift */,
-				OBJ_141 /* LockOwnerType.swift */,
-				OBJ_142 /* MainScheduler.swift */,
-				OBJ_143 /* Map.swift */,
-				OBJ_144 /* Materialize.swift */,
-				OBJ_145 /* Maybe.swift */,
-				OBJ_146 /* Merge.swift */,
-				OBJ_147 /* Multicast.swift */,
-				OBJ_148 /* Never.swift */,
-				OBJ_149 /* NopDisposable.swift */,
-				OBJ_150 /* Observable.swift */,
-				OBJ_151 /* ObservableConvertibleType.swift */,
-				OBJ_152 /* ObservableType+Extensions.swift */,
-				OBJ_153 /* ObservableType+PrimitiveSequence.swift */,
-				OBJ_154 /* ObservableType.swift */,
-				OBJ_155 /* ObserveOn.swift */,
-				OBJ_156 /* ObserverBase.swift */,
-				OBJ_157 /* ObserverType.swift */,
-				OBJ_158 /* OperationQueueScheduler.swift */,
-				OBJ_159 /* Optional.swift */,
-				OBJ_160 /* Platform.Darwin.swift */,
-				OBJ_161 /* Platform.Linux.swift */,
-				OBJ_162 /* PrimitiveSequence+Zip+arity.swift */,
-				OBJ_163 /* PrimitiveSequence.swift */,
-				OBJ_164 /* PriorityQueue.swift */,
-				OBJ_165 /* Producer.swift */,
-				OBJ_166 /* PublishSubject.swift */,
-				OBJ_167 /* Queue.swift */,
-				OBJ_168 /* Range.swift */,
-				OBJ_169 /* Reactive.swift */,
-				OBJ_170 /* RecursiveLock.swift */,
-				OBJ_171 /* RecursiveScheduler.swift */,
-				OBJ_172 /* Reduce.swift */,
-				OBJ_173 /* RefCountDisposable.swift */,
-				OBJ_174 /* Repeat.swift */,
-				OBJ_175 /* ReplaySubject.swift */,
-				OBJ_176 /* RetryWhen.swift */,
-				OBJ_177 /* Rx.swift */,
-				OBJ_178 /* RxMutableBox.swift */,
-				OBJ_179 /* Sample.swift */,
-				OBJ_180 /* Scan.swift */,
-				OBJ_181 /* ScheduledDisposable.swift */,
-				OBJ_182 /* ScheduledItem.swift */,
-				OBJ_183 /* ScheduledItemType.swift */,
-				OBJ_184 /* SchedulerServices+Emulation.swift */,
-				OBJ_185 /* SchedulerType.swift */,
-				OBJ_186 /* Sequence.swift */,
-				OBJ_187 /* SerialDispatchQueueScheduler.swift */,
-				OBJ_188 /* SerialDisposable.swift */,
-				OBJ_189 /* ShareReplayScope.swift */,
-				OBJ_190 /* Single.swift */,
-				OBJ_191 /* SingleAssignmentDisposable.swift */,
-				OBJ_192 /* SingleAsync.swift */,
-				OBJ_193 /* Sink.swift */,
-				OBJ_194 /* Skip.swift */,
-				OBJ_195 /* SkipUntil.swift */,
-				OBJ_196 /* SkipWhile.swift */,
-				OBJ_197 /* StartWith.swift */,
-				OBJ_198 /* String+Rx.swift */,
-				OBJ_199 /* SubjectType.swift */,
-				OBJ_200 /* SubscribeOn.swift */,
-				OBJ_201 /* SubscriptionDisposable.swift */,
-				OBJ_202 /* SwiftSupport.swift */,
-				OBJ_203 /* Switch.swift */,
-				OBJ_204 /* SwitchIfEmpty.swift */,
-				OBJ_205 /* SynchronizedDisposeType.swift */,
-				OBJ_206 /* SynchronizedOnType.swift */,
-				OBJ_207 /* SynchronizedUnsubscribeType.swift */,
-				OBJ_208 /* TailRecursiveSink.swift */,
-				OBJ_209 /* Take.swift */,
-				OBJ_210 /* TakeLast.swift */,
-				OBJ_211 /* TakeUntil.swift */,
-				OBJ_212 /* TakeWhile.swift */,
-				OBJ_213 /* Throttle.swift */,
-				OBJ_214 /* Timeout.swift */,
-				OBJ_215 /* Timer.swift */,
-				OBJ_216 /* ToArray.swift */,
-				OBJ_217 /* Using.swift */,
-				OBJ_218 /* VirtualTimeConverterType.swift */,
-				OBJ_219 /* VirtualTimeScheduler.swift */,
-				OBJ_220 /* Window.swift */,
-				OBJ_221 /* WithLatestFrom.swift */,
-				OBJ_222 /* Zip+Collection.swift */,
-				OBJ_223 /* Zip+arity.swift */,
-				OBJ_224 /* Zip.swift */,
-			);
-			name = RxSwift;
-			path = .build/checkouts/RxSwift/Sources/RxSwift;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_8 /* XCoordinator */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_9 /* Animation.swift */,
-				OBJ_10 /* AnyCoordinator.swift */,
-				OBJ_11 /* AnyTransitionPerformer.swift */,
-				OBJ_12 /* BaseCoordinator.swift */,
-				OBJ_13 /* BasicCoordinator.swift */,
-				OBJ_14 /* Container.swift */,
-				OBJ_15 /* Coordinator.swift */,
-				OBJ_16 /* CoordinatorPreviewingDelegateObject.swift */,
-				OBJ_17 /* DeepLinking.swift */,
-				OBJ_18 /* GestureRecognizerTarget.swift */,
-				OBJ_19 /* InteractiveTransitionAnimation.swift */,
-				OBJ_20 /* InterruptibleTransitionAnimation.swift */,
-				OBJ_21 /* NavigationAnimationDelegate.swift */,
-				OBJ_22 /* NavigationCoordinator.swift */,
-				OBJ_23 /* NavigationTransition.swift */,
-				OBJ_24 /* PageCoordinator.swift */,
-				OBJ_25 /* PageCoordinatorDataSource.swift */,
-				OBJ_26 /* PageTransition.swift */,
-				OBJ_27 /* Presentable.swift */,
-				OBJ_28 /* RedirectionRouter.swift */,
-				OBJ_29 /* Route.swift */,
-				OBJ_30 /* Router.swift */,
-				OBJ_31 /* SplitCoordinator.swift */,
-				OBJ_32 /* SplitTransition.swift */,
-				OBJ_33 /* StaticTransitionAnimation.swift */,
-				OBJ_34 /* StrongRouter.swift */,
-				OBJ_35 /* TabBarAnimationDelegate.swift */,
-				OBJ_36 /* TabBarCoordinator.swift */,
-				OBJ_37 /* TabBarTransition.swift */,
-				OBJ_38 /* Transition+Init.swift */,
-				OBJ_39 /* Transition.swift */,
-				OBJ_40 /* TransitionAnimation.swift */,
-				OBJ_41 /* TransitionOptions.swift */,
-				OBJ_42 /* TransitionPerformer.swift */,
-				OBJ_43 /* TransitionProtocol.swift */,
-				OBJ_44 /* UINavigationController+Transition.swift */,
-				OBJ_45 /* UIPageViewController+Transition.swift */,
-				OBJ_46 /* UITabBarController+Transition.swift */,
-				OBJ_47 /* UIView+Store.swift */,
-				OBJ_48 /* UIViewController+Transition.swift */,
-				OBJ_49 /* UnownedErased+Router.swift */,
-				OBJ_50 /* UnownedErased.swift */,
-				OBJ_51 /* ViewCoordinator.swift */,
-				OBJ_52 /* WeakErased+Router.swift */,
-				OBJ_53 /* WeakErased.swift */,
-			);
-			name = XCoordinator;
-			path = Sources/XCoordinator;
-			sourceTree = SOURCE_ROOT;
-		};
-/* End PBXGroup section */
-
-/* Begin PBXNativeTarget section */
-		"RxSwift::RxSwift" /* RxSwift */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_240 /* Build configuration list for PBXNativeTarget "RxSwift" */;
-			buildPhases = (
-				OBJ_243 /* Sources */,
-				OBJ_395 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = RxSwift;
-			productName = RxSwift;
-			productReference = "RxSwift::RxSwift::Product" /* RxSwift.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		"RxSwift::SwiftPMPackageDescription" /* RxSwiftPackageDescription */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_397 /* Build configuration list for PBXNativeTarget "RxSwiftPackageDescription" */;
-			buildPhases = (
-				OBJ_400 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = RxSwiftPackageDescription;
-			productName = RxSwiftPackageDescription;
-			productType = "com.apple.product-type.framework";
-		};
-		"XCoordinator::SwiftPMPackageDescription" /* XCoordinatorPackageDescription */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_463 /* Build configuration list for PBXNativeTarget "XCoordinatorPackageDescription" */;
-			buildPhases = (
-				OBJ_466 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = XCoordinatorPackageDescription;
-			productName = XCoordinatorPackageDescription;
-			productType = "com.apple.product-type.framework";
-		};
-		"XCoordinator::XCoordinator" /* XCoordinator */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_403 /* Build configuration list for PBXNativeTarget "XCoordinator" */;
-			buildPhases = (
-				9BC82EBE233D8CE400C604A8 /* ShellScript */,
-				OBJ_406 /* Sources */,
-				OBJ_452 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = XCoordinator;
-			productName = XCoordinator;
-			productReference = "XCoordinator::XCoordinator::Product" /* XCoordinator.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		"XCoordinator::XCoordinatorCombine" /* XCoordinatorCombine */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_454 /* Build configuration list for PBXNativeTarget "XCoordinatorCombine" */;
-			buildPhases = (
-				OBJ_457 /* Sources */,
-				OBJ_459 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				OBJ_461 /* PBXTargetDependency */,
-			);
-			name = XCoordinatorCombine;
-			productName = XCoordinatorCombine;
-			productReference = "XCoordinator::XCoordinatorCombine::Product" /* XCoordinatorCombine.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		"XCoordinator::XCoordinatorRx" /* XCoordinatorRx */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_475 /* Build configuration list for PBXNativeTarget "XCoordinatorRx" */;
-			buildPhases = (
-				OBJ_478 /* Sources */,
-				OBJ_480 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				OBJ_483 /* PBXTargetDependency */,
-				OBJ_484 /* PBXTargetDependency */,
-			);
-			name = XCoordinatorRx;
-			productName = XCoordinatorRx;
-			productReference = "XCoordinator::XCoordinatorRx::Product" /* XCoordinatorRx.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		"XCoordinator::XCoordinatorTests" /* XCoordinatorTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_485 /* Build configuration list for PBXNativeTarget "XCoordinatorTests" */;
-			buildPhases = (
-				OBJ_488 /* Sources */,
-				OBJ_495 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				OBJ_499 /* PBXTargetDependency */,
-				OBJ_500 /* PBXTargetDependency */,
-				OBJ_501 /* PBXTargetDependency */,
-			);
-			name = XCoordinatorTests;
-			productName = XCoordinatorTests;
-			productReference = "XCoordinator::XCoordinatorTests::Product" /* XCoordinatorTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		OBJ_1 /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastSwiftMigration = 9999;
-				LastUpgradeCheck = 1130;
-			};
-			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "XCoordinator" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = en;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-				Base,
-			);
-			mainGroup = OBJ_5;
-			productRefGroup = OBJ_227 /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				"RxSwift::RxSwift" /* RxSwift */,
-				"RxSwift::SwiftPMPackageDescription" /* RxSwiftPackageDescription */,
-				"XCoordinator::XCoordinator" /* XCoordinator */,
-				"XCoordinator::XCoordinatorCombine" /* XCoordinatorCombine */,
-				"XCoordinator::SwiftPMPackageDescription" /* XCoordinatorPackageDescription */,
-				"XCoordinator::XCoordinatorPackageTests::ProductTarget" /* XCoordinatorPackageTests */,
-				"XCoordinator::XCoordinatorRx" /* XCoordinatorRx */,
-				"XCoordinator::XCoordinatorTests" /* XCoordinatorTests */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		9BC82EBE233D8CE400C604A8 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nswift package update\n";
-		};
-/* End PBXShellScriptBuildPhase section */
-
-/* Begin PBXSourcesBuildPhase section */
-		OBJ_243 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_244 /* AddRef.swift in Sources */,
-				OBJ_245 /* Amb.swift in Sources */,
-				OBJ_246 /* AnonymousDisposable.swift in Sources */,
-				OBJ_247 /* AnonymousObserver.swift in Sources */,
-				OBJ_248 /* AnyObserver.swift in Sources */,
-				OBJ_249 /* AsMaybe.swift in Sources */,
-				OBJ_250 /* AsSingle.swift in Sources */,
-				OBJ_251 /* AsyncLock.swift in Sources */,
-				OBJ_252 /* AsyncSubject.swift in Sources */,
-				OBJ_253 /* AtomicInt.swift in Sources */,
-				OBJ_254 /* Bag+Rx.swift in Sources */,
-				OBJ_255 /* Bag.swift in Sources */,
-				OBJ_256 /* BehaviorSubject.swift in Sources */,
-				OBJ_257 /* BinaryDisposable.swift in Sources */,
-				OBJ_258 /* BooleanDisposable.swift in Sources */,
-				OBJ_259 /* Buffer.swift in Sources */,
-				OBJ_260 /* Cancelable.swift in Sources */,
-				OBJ_261 /* Catch.swift in Sources */,
-				OBJ_262 /* CombineLatest+Collection.swift in Sources */,
-				OBJ_263 /* CombineLatest+arity.swift in Sources */,
-				OBJ_264 /* CombineLatest.swift in Sources */,
-				OBJ_265 /* CompactMap.swift in Sources */,
-				OBJ_266 /* Completable+AndThen.swift in Sources */,
-				OBJ_267 /* Completable.swift in Sources */,
-				OBJ_268 /* CompositeDisposable.swift in Sources */,
-				OBJ_269 /* Concat.swift in Sources */,
-				OBJ_270 /* ConcurrentDispatchQueueScheduler.swift in Sources */,
-				OBJ_271 /* ConcurrentMainScheduler.swift in Sources */,
-				OBJ_272 /* ConnectableObservableType.swift in Sources */,
-				OBJ_273 /* Create.swift in Sources */,
-				OBJ_274 /* CurrentThreadScheduler.swift in Sources */,
-				OBJ_275 /* Date+Dispatch.swift in Sources */,
-				OBJ_276 /* Debounce.swift in Sources */,
-				OBJ_277 /* Debug.swift in Sources */,
-				OBJ_278 /* DefaultIfEmpty.swift in Sources */,
-				OBJ_279 /* Deferred.swift in Sources */,
-				OBJ_280 /* Delay.swift in Sources */,
-				OBJ_281 /* DelaySubscription.swift in Sources */,
-				OBJ_282 /* Dematerialize.swift in Sources */,
-				OBJ_283 /* Deprecated.swift in Sources */,
-				OBJ_284 /* DispatchQueue+Extensions.swift in Sources */,
-				OBJ_285 /* DispatchQueueConfiguration.swift in Sources */,
-				OBJ_286 /* Disposable.swift in Sources */,
-				OBJ_287 /* Disposables.swift in Sources */,
-				OBJ_288 /* DisposeBag.swift in Sources */,
-				OBJ_289 /* DisposeBase.swift in Sources */,
-				OBJ_290 /* DistinctUntilChanged.swift in Sources */,
-				OBJ_291 /* Do.swift in Sources */,
-				OBJ_292 /* ElementAt.swift in Sources */,
-				OBJ_293 /* Empty.swift in Sources */,
-				OBJ_294 /* Enumerated.swift in Sources */,
-				OBJ_295 /* Error.swift in Sources */,
-				OBJ_296 /* Errors.swift in Sources */,
-				OBJ_297 /* Event.swift in Sources */,
-				OBJ_298 /* Filter.swift in Sources */,
-				OBJ_299 /* First.swift in Sources */,
-				OBJ_300 /* Generate.swift in Sources */,
-				OBJ_301 /* GroupBy.swift in Sources */,
-				OBJ_302 /* GroupedObservable.swift in Sources */,
-				OBJ_303 /* HistoricalScheduler.swift in Sources */,
-				OBJ_304 /* HistoricalSchedulerTimeConverter.swift in Sources */,
-				OBJ_305 /* ImmediateSchedulerType.swift in Sources */,
-				OBJ_306 /* InfiniteSequence.swift in Sources */,
-				OBJ_307 /* InvocableScheduledItem.swift in Sources */,
-				OBJ_308 /* InvocableType.swift in Sources */,
-				OBJ_309 /* Just.swift in Sources */,
-				OBJ_310 /* Lock.swift in Sources */,
-				OBJ_311 /* LockOwnerType.swift in Sources */,
-				OBJ_312 /* MainScheduler.swift in Sources */,
-				OBJ_313 /* Map.swift in Sources */,
-				OBJ_314 /* Materialize.swift in Sources */,
-				OBJ_315 /* Maybe.swift in Sources */,
-				OBJ_316 /* Merge.swift in Sources */,
-				OBJ_317 /* Multicast.swift in Sources */,
-				OBJ_318 /* Never.swift in Sources */,
-				OBJ_319 /* NopDisposable.swift in Sources */,
-				OBJ_320 /* Observable.swift in Sources */,
-				OBJ_321 /* ObservableConvertibleType.swift in Sources */,
-				OBJ_322 /* ObservableType+Extensions.swift in Sources */,
-				OBJ_323 /* ObservableType+PrimitiveSequence.swift in Sources */,
-				OBJ_324 /* ObservableType.swift in Sources */,
-				OBJ_325 /* ObserveOn.swift in Sources */,
-				OBJ_326 /* ObserverBase.swift in Sources */,
-				OBJ_327 /* ObserverType.swift in Sources */,
-				OBJ_328 /* OperationQueueScheduler.swift in Sources */,
-				OBJ_329 /* Optional.swift in Sources */,
-				OBJ_330 /* Platform.Darwin.swift in Sources */,
-				OBJ_331 /* Platform.Linux.swift in Sources */,
-				OBJ_332 /* PrimitiveSequence+Zip+arity.swift in Sources */,
-				OBJ_333 /* PrimitiveSequence.swift in Sources */,
-				OBJ_334 /* PriorityQueue.swift in Sources */,
-				OBJ_335 /* Producer.swift in Sources */,
-				OBJ_336 /* PublishSubject.swift in Sources */,
-				OBJ_337 /* Queue.swift in Sources */,
-				OBJ_338 /* Range.swift in Sources */,
-				OBJ_339 /* Reactive.swift in Sources */,
-				OBJ_340 /* RecursiveLock.swift in Sources */,
-				OBJ_341 /* RecursiveScheduler.swift in Sources */,
-				OBJ_342 /* Reduce.swift in Sources */,
-				OBJ_343 /* RefCountDisposable.swift in Sources */,
-				OBJ_344 /* Repeat.swift in Sources */,
-				OBJ_345 /* ReplaySubject.swift in Sources */,
-				OBJ_346 /* RetryWhen.swift in Sources */,
-				OBJ_347 /* Rx.swift in Sources */,
-				OBJ_348 /* RxMutableBox.swift in Sources */,
-				OBJ_349 /* Sample.swift in Sources */,
-				OBJ_350 /* Scan.swift in Sources */,
-				OBJ_351 /* ScheduledDisposable.swift in Sources */,
-				OBJ_352 /* ScheduledItem.swift in Sources */,
-				OBJ_353 /* ScheduledItemType.swift in Sources */,
-				OBJ_354 /* SchedulerServices+Emulation.swift in Sources */,
-				OBJ_355 /* SchedulerType.swift in Sources */,
-				OBJ_356 /* Sequence.swift in Sources */,
-				OBJ_357 /* SerialDispatchQueueScheduler.swift in Sources */,
-				OBJ_358 /* SerialDisposable.swift in Sources */,
-				OBJ_359 /* ShareReplayScope.swift in Sources */,
-				OBJ_360 /* Single.swift in Sources */,
-				OBJ_361 /* SingleAssignmentDisposable.swift in Sources */,
-				OBJ_362 /* SingleAsync.swift in Sources */,
-				OBJ_363 /* Sink.swift in Sources */,
-				OBJ_364 /* Skip.swift in Sources */,
-				OBJ_365 /* SkipUntil.swift in Sources */,
-				OBJ_366 /* SkipWhile.swift in Sources */,
-				OBJ_367 /* StartWith.swift in Sources */,
-				OBJ_368 /* String+Rx.swift in Sources */,
-				OBJ_369 /* SubjectType.swift in Sources */,
-				OBJ_370 /* SubscribeOn.swift in Sources */,
-				OBJ_371 /* SubscriptionDisposable.swift in Sources */,
-				OBJ_372 /* SwiftSupport.swift in Sources */,
-				OBJ_373 /* Switch.swift in Sources */,
-				OBJ_374 /* SwitchIfEmpty.swift in Sources */,
-				OBJ_375 /* SynchronizedDisposeType.swift in Sources */,
-				OBJ_376 /* SynchronizedOnType.swift in Sources */,
-				OBJ_377 /* SynchronizedUnsubscribeType.swift in Sources */,
-				OBJ_378 /* TailRecursiveSink.swift in Sources */,
-				OBJ_379 /* Take.swift in Sources */,
-				OBJ_380 /* TakeLast.swift in Sources */,
-				OBJ_381 /* TakeUntil.swift in Sources */,
-				OBJ_382 /* TakeWhile.swift in Sources */,
-				OBJ_383 /* Throttle.swift in Sources */,
-				OBJ_384 /* Timeout.swift in Sources */,
-				OBJ_385 /* Timer.swift in Sources */,
-				OBJ_386 /* ToArray.swift in Sources */,
-				OBJ_387 /* Using.swift in Sources */,
-				OBJ_388 /* VirtualTimeConverterType.swift in Sources */,
-				OBJ_389 /* VirtualTimeScheduler.swift in Sources */,
-				OBJ_390 /* Window.swift in Sources */,
-				OBJ_391 /* WithLatestFrom.swift in Sources */,
-				OBJ_392 /* Zip+Collection.swift in Sources */,
-				OBJ_393 /* Zip+arity.swift in Sources */,
-				OBJ_394 /* Zip.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_400 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_401 /* Package.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_406 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_407 /* Animation.swift in Sources */,
-				OBJ_408 /* AnyCoordinator.swift in Sources */,
-				OBJ_409 /* AnyTransitionPerformer.swift in Sources */,
-				OBJ_410 /* BaseCoordinator.swift in Sources */,
-				OBJ_411 /* BasicCoordinator.swift in Sources */,
-				OBJ_412 /* Container.swift in Sources */,
-				OBJ_413 /* Coordinator.swift in Sources */,
-				OBJ_414 /* CoordinatorPreviewingDelegateObject.swift in Sources */,
-				OBJ_415 /* DeepLinking.swift in Sources */,
-				OBJ_416 /* GestureRecognizerTarget.swift in Sources */,
-				OBJ_417 /* InteractiveTransitionAnimation.swift in Sources */,
-				OBJ_418 /* InterruptibleTransitionAnimation.swift in Sources */,
-				OBJ_419 /* NavigationAnimationDelegate.swift in Sources */,
-				OBJ_420 /* NavigationCoordinator.swift in Sources */,
-				OBJ_421 /* NavigationTransition.swift in Sources */,
-				OBJ_422 /* PageCoordinator.swift in Sources */,
-				OBJ_423 /* PageCoordinatorDataSource.swift in Sources */,
-				OBJ_424 /* PageTransition.swift in Sources */,
-				OBJ_425 /* Presentable.swift in Sources */,
-				OBJ_426 /* RedirectionRouter.swift in Sources */,
-				OBJ_427 /* Route.swift in Sources */,
-				OBJ_428 /* Router.swift in Sources */,
-				OBJ_429 /* SplitCoordinator.swift in Sources */,
-				OBJ_430 /* SplitTransition.swift in Sources */,
-				OBJ_431 /* StaticTransitionAnimation.swift in Sources */,
-				OBJ_432 /* StrongRouter.swift in Sources */,
-				OBJ_433 /* TabBarAnimationDelegate.swift in Sources */,
-				OBJ_434 /* TabBarCoordinator.swift in Sources */,
-				OBJ_435 /* TabBarTransition.swift in Sources */,
-				OBJ_436 /* Transition+Init.swift in Sources */,
-				OBJ_437 /* Transition.swift in Sources */,
-				OBJ_438 /* TransitionAnimation.swift in Sources */,
-				OBJ_439 /* TransitionOptions.swift in Sources */,
-				OBJ_440 /* TransitionPerformer.swift in Sources */,
-				OBJ_441 /* TransitionProtocol.swift in Sources */,
-				OBJ_442 /* UINavigationController+Transition.swift in Sources */,
-				OBJ_443 /* UIPageViewController+Transition.swift in Sources */,
-				OBJ_444 /* UITabBarController+Transition.swift in Sources */,
-				OBJ_445 /* UIView+Store.swift in Sources */,
-				OBJ_446 /* UIViewController+Transition.swift in Sources */,
-				OBJ_447 /* UnownedErased+Router.swift in Sources */,
-				OBJ_448 /* UnownedErased.swift in Sources */,
-				OBJ_449 /* ViewCoordinator.swift in Sources */,
-				OBJ_450 /* WeakErased+Router.swift in Sources */,
-				OBJ_451 /* WeakErased.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_457 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_458 /* Router+Combine.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_466 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_467 /* Package.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_478 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_479 /* Router+Rx.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_488 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_489 /* AnimationTests.swift in Sources */,
-				OBJ_490 /* TestAnimation.swift in Sources */,
-				OBJ_491 /* TestRoute.swift in Sources */,
-				OBJ_492 /* TransitionTests.swift in Sources */,
-				OBJ_493 /* XCTestManifests.swift in Sources */,
-				OBJ_494 /* XCText+Extras.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		OBJ_461 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "XCoordinator::XCoordinator" /* XCoordinator */;
-			targetProxy = 9BC82EB9233D8CD000C604A8 /* PBXContainerItemProxy */;
-		};
-		OBJ_472 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "XCoordinator::XCoordinatorTests" /* XCoordinatorTests */;
-			targetProxy = 9BC82EBD233D8CD100C604A8 /* PBXContainerItemProxy */;
-		};
-		OBJ_483 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "RxSwift::RxSwift" /* RxSwift */;
-			targetProxy = 9BC82EB7233D8CD000C604A8 /* PBXContainerItemProxy */;
-		};
-		OBJ_484 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "XCoordinator::XCoordinator" /* XCoordinator */;
-			targetProxy = 9BC82EB8233D8CD000C604A8 /* PBXContainerItemProxy */;
-		};
-		OBJ_499 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "XCoordinator::XCoordinatorRx" /* XCoordinatorRx */;
-			targetProxy = 9BC82EBA233D8CD100C604A8 /* PBXContainerItemProxy */;
-		};
-		OBJ_500 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "RxSwift::RxSwift" /* RxSwift */;
-			targetProxy = 9BC82EBB233D8CD100C604A8 /* PBXContainerItemProxy */;
-		};
-		OBJ_501 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "XCoordinator::XCoordinator" /* XCoordinator */;
-			targetProxy = 9BC82EBC233D8CD100C604A8 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
-/* Begin XCBuildConfiguration section */
-		OBJ_241 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = XCoordinator.xcodeproj/RxSwift_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = RxSwift;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
-				TARGET_NAME = RxSwift;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
-			};
-			name = Debug;
-		};
-		OBJ_242 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = XCoordinator.xcodeproj/RxSwift_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = RxSwift;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
-				TARGET_NAME = RxSwift;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
-			};
-			name = Release;
-		};
-		OBJ_3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COMBINE_HIDPI_IMAGES = YES;
-				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_NS_ASSERTIONS = YES;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"SWIFT_PACKAGE=1",
-					"DEBUG=1",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE DEBUG";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		OBJ_398 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		OBJ_399 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		OBJ_4 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COMBINE_HIDPI_IMAGES = YES;
-				COPY_PHASE_STRIP = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = s;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"SWIFT_PACKAGE=1",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		OBJ_404 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = XCoordinator.xcodeproj/XCoordinator_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = XCoordinator;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
-				TARGET_NAME = XCoordinator;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
-			};
-			name = Debug;
-		};
-		OBJ_405 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = XCoordinator.xcodeproj/XCoordinator_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = XCoordinator;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
-				TARGET_NAME = XCoordinator;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
-			};
-			name = Release;
-		};
-		OBJ_455 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = XCoordinator.xcodeproj/XCoordinatorCombine_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = XCoordinatorCombine;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
-				TARGET_NAME = XCoordinatorCombine;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
-			};
-			name = Debug;
-		};
-		OBJ_456 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = XCoordinator.xcodeproj/XCoordinatorCombine_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = XCoordinatorCombine;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
-				TARGET_NAME = XCoordinatorCombine;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
-			};
-			name = Release;
-		};
-		OBJ_464 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.1";
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		OBJ_465 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.1";
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		OBJ_470 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		OBJ_471 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		OBJ_476 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = XCoordinator.xcodeproj/XCoordinatorRx_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = XCoordinatorRx;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
-				TARGET_NAME = XCoordinatorRx;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
-			};
-			name = Debug;
-		};
-		OBJ_477 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = XCoordinator.xcodeproj/XCoordinatorRx_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = XCoordinatorRx;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
-				TARGET_NAME = XCoordinatorRx;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
-			};
-			name = Release;
-		};
-		OBJ_486 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CLANG_ENABLE_MODULES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = XCoordinator.xcodeproj/XCoordinatorTests_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
-				TARGET_NAME = XCoordinatorTests;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
-			};
-			name = Debug;
-		};
-		OBJ_487 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CLANG_ENABLE_MODULES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = XCoordinator.xcodeproj/XCoordinatorTests_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
-				TARGET_NAME = XCoordinatorTests;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		OBJ_2 /* Build configuration list for PBXProject "XCoordinator" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_3 /* Debug */,
-				OBJ_4 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_240 /* Build configuration list for PBXNativeTarget "RxSwift" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_241 /* Debug */,
-				OBJ_242 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_397 /* Build configuration list for PBXNativeTarget "RxSwiftPackageDescription" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_398 /* Debug */,
-				OBJ_399 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_403 /* Build configuration list for PBXNativeTarget "XCoordinator" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_404 /* Debug */,
-				OBJ_405 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_454 /* Build configuration list for PBXNativeTarget "XCoordinatorCombine" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_455 /* Debug */,
-				OBJ_456 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_463 /* Build configuration list for PBXNativeTarget "XCoordinatorPackageDescription" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_464 /* Debug */,
-				OBJ_465 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_469 /* Build configuration list for PBXAggregateTarget "XCoordinatorPackageTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_470 /* Debug */,
-				OBJ_471 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_475 /* Build configuration list for PBXNativeTarget "XCoordinatorRx" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_476 /* Debug */,
-				OBJ_477 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_485 /* Build configuration list for PBXNativeTarget "XCoordinatorTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_486 /* Debug */,
-				OBJ_487 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = OBJ_1 /* Project object */;
+   archiveVersion = "1";
+   objectVersion = "46";
+   objects = {
+      "OBJ_1" = {
+         isa = "PBXProject";
+         attributes = {
+            LastSwiftMigration = "9999";
+            LastUpgradeCheck = "9999";
+         };
+         buildConfigurationList = "OBJ_2";
+         compatibilityVersion = "Xcode 3.2";
+         developmentRegion = "en";
+         hasScannedForEncodings = "0";
+         knownRegions = (
+            "en"
+         );
+         mainGroup = "OBJ_5";
+         productRefGroup = "OBJ_226";
+         projectDirPath = ".";
+         targets = (
+            "RxSwift::RxSwift",
+            "RxSwift::SwiftPMPackageDescription",
+            "XCoordinator::XCoordinator",
+            "XCoordinator::XCoordinatorCombine",
+            "XCoordinator::SwiftPMPackageDescription",
+            "XCoordinator::XCoordinatorPackageTests::ProductTarget",
+            "XCoordinator::XCoordinatorRx",
+            "XCoordinator::XCoordinatorTests"
+         );
+      };
+      "OBJ_10" = {
+         isa = "PBXFileReference";
+         path = "AnyCoordinator.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_100" = {
+         isa = "PBXFileReference";
+         path = "ConcurrentDispatchQueueScheduler.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_101" = {
+         isa = "PBXFileReference";
+         path = "ConcurrentMainScheduler.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_102" = {
+         isa = "PBXFileReference";
+         path = "ConnectableObservableType.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_103" = {
+         isa = "PBXFileReference";
+         path = "Create.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_104" = {
+         isa = "PBXFileReference";
+         path = "CurrentThreadScheduler.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_105" = {
+         isa = "PBXFileReference";
+         path = "Date+Dispatch.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_106" = {
+         isa = "PBXFileReference";
+         path = "Debounce.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_107" = {
+         isa = "PBXFileReference";
+         path = "Debug.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_108" = {
+         isa = "PBXFileReference";
+         path = "DefaultIfEmpty.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_109" = {
+         isa = "PBXFileReference";
+         path = "Deferred.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_11" = {
+         isa = "PBXFileReference";
+         path = "AnyTransitionPerformer.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_110" = {
+         isa = "PBXFileReference";
+         path = "Delay.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_111" = {
+         isa = "PBXFileReference";
+         path = "DelaySubscription.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_112" = {
+         isa = "PBXFileReference";
+         path = "Dematerialize.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_113" = {
+         isa = "PBXFileReference";
+         path = "Deprecated.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_114" = {
+         isa = "PBXFileReference";
+         path = "DispatchQueue+Extensions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_115" = {
+         isa = "PBXFileReference";
+         path = "DispatchQueueConfiguration.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_116" = {
+         isa = "PBXFileReference";
+         path = "Disposable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_117" = {
+         isa = "PBXFileReference";
+         path = "Disposables.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_118" = {
+         isa = "PBXFileReference";
+         path = "DisposeBag.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_119" = {
+         isa = "PBXFileReference";
+         path = "DisposeBase.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_12" = {
+         isa = "PBXFileReference";
+         path = "BaseCoordinator.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_120" = {
+         isa = "PBXFileReference";
+         path = "DistinctUntilChanged.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_121" = {
+         isa = "PBXFileReference";
+         path = "Do.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_122" = {
+         isa = "PBXFileReference";
+         path = "ElementAt.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_123" = {
+         isa = "PBXFileReference";
+         path = "Empty.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_124" = {
+         isa = "PBXFileReference";
+         path = "Enumerated.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_125" = {
+         isa = "PBXFileReference";
+         path = "Error.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_126" = {
+         isa = "PBXFileReference";
+         path = "Errors.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_127" = {
+         isa = "PBXFileReference";
+         path = "Event.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_128" = {
+         isa = "PBXFileReference";
+         path = "Filter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_129" = {
+         isa = "PBXFileReference";
+         path = "First.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_13" = {
+         isa = "PBXFileReference";
+         path = "BasicCoordinator.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_130" = {
+         isa = "PBXFileReference";
+         path = "Generate.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_131" = {
+         isa = "PBXFileReference";
+         path = "GroupBy.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_132" = {
+         isa = "PBXFileReference";
+         path = "GroupedObservable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_133" = {
+         isa = "PBXFileReference";
+         path = "HistoricalScheduler.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_134" = {
+         isa = "PBXFileReference";
+         path = "HistoricalSchedulerTimeConverter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_135" = {
+         isa = "PBXFileReference";
+         path = "ImmediateSchedulerType.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_136" = {
+         isa = "PBXFileReference";
+         path = "InfiniteSequence.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_137" = {
+         isa = "PBXFileReference";
+         path = "InvocableScheduledItem.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_138" = {
+         isa = "PBXFileReference";
+         path = "InvocableType.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_139" = {
+         isa = "PBXFileReference";
+         path = "Just.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_14" = {
+         isa = "PBXFileReference";
+         path = "Container.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_140" = {
+         isa = "PBXFileReference";
+         path = "Lock.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_141" = {
+         isa = "PBXFileReference";
+         path = "LockOwnerType.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_142" = {
+         isa = "PBXFileReference";
+         path = "MainScheduler.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_143" = {
+         isa = "PBXFileReference";
+         path = "Map.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_144" = {
+         isa = "PBXFileReference";
+         path = "Materialize.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_145" = {
+         isa = "PBXFileReference";
+         path = "Maybe.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_146" = {
+         isa = "PBXFileReference";
+         path = "Merge.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_147" = {
+         isa = "PBXFileReference";
+         path = "Multicast.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_148" = {
+         isa = "PBXFileReference";
+         path = "Never.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_149" = {
+         isa = "PBXFileReference";
+         path = "NopDisposable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_15" = {
+         isa = "PBXFileReference";
+         path = "Coordinator.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_150" = {
+         isa = "PBXFileReference";
+         path = "Observable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_151" = {
+         isa = "PBXFileReference";
+         path = "ObservableConvertibleType.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_152" = {
+         isa = "PBXFileReference";
+         path = "ObservableType+Extensions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_153" = {
+         isa = "PBXFileReference";
+         path = "ObservableType+PrimitiveSequence.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_154" = {
+         isa = "PBXFileReference";
+         path = "ObservableType.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_155" = {
+         isa = "PBXFileReference";
+         path = "ObserveOn.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_156" = {
+         isa = "PBXFileReference";
+         path = "ObserverBase.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_157" = {
+         isa = "PBXFileReference";
+         path = "ObserverType.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_158" = {
+         isa = "PBXFileReference";
+         path = "OperationQueueScheduler.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_159" = {
+         isa = "PBXFileReference";
+         path = "Optional.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_16" = {
+         isa = "PBXFileReference";
+         path = "CoordinatorPreviewingDelegateObject.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_160" = {
+         isa = "PBXFileReference";
+         path = "Platform.Darwin.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_161" = {
+         isa = "PBXFileReference";
+         path = "Platform.Linux.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_162" = {
+         isa = "PBXFileReference";
+         path = "PrimitiveSequence+Zip+arity.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_163" = {
+         isa = "PBXFileReference";
+         path = "PrimitiveSequence.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_164" = {
+         isa = "PBXFileReference";
+         path = "PriorityQueue.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_165" = {
+         isa = "PBXFileReference";
+         path = "Producer.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_166" = {
+         isa = "PBXFileReference";
+         path = "PublishSubject.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_167" = {
+         isa = "PBXFileReference";
+         path = "Queue.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_168" = {
+         isa = "PBXFileReference";
+         path = "Range.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_169" = {
+         isa = "PBXFileReference";
+         path = "Reactive.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_17" = {
+         isa = "PBXFileReference";
+         path = "DeepLinking.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_170" = {
+         isa = "PBXFileReference";
+         path = "RecursiveLock.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_171" = {
+         isa = "PBXFileReference";
+         path = "RecursiveScheduler.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_172" = {
+         isa = "PBXFileReference";
+         path = "Reduce.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_173" = {
+         isa = "PBXFileReference";
+         path = "RefCountDisposable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_174" = {
+         isa = "PBXFileReference";
+         path = "Repeat.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_175" = {
+         isa = "PBXFileReference";
+         path = "ReplaySubject.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_176" = {
+         isa = "PBXFileReference";
+         path = "RetryWhen.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_177" = {
+         isa = "PBXFileReference";
+         path = "Rx.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_178" = {
+         isa = "PBXFileReference";
+         path = "RxMutableBox.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_179" = {
+         isa = "PBXFileReference";
+         path = "Sample.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_18" = {
+         isa = "PBXFileReference";
+         path = "GestureRecognizerTarget.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_180" = {
+         isa = "PBXFileReference";
+         path = "Scan.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_181" = {
+         isa = "PBXFileReference";
+         path = "ScheduledDisposable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_182" = {
+         isa = "PBXFileReference";
+         path = "ScheduledItem.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_183" = {
+         isa = "PBXFileReference";
+         path = "ScheduledItemType.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_184" = {
+         isa = "PBXFileReference";
+         path = "SchedulerServices+Emulation.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_185" = {
+         isa = "PBXFileReference";
+         path = "SchedulerType.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_186" = {
+         isa = "PBXFileReference";
+         path = "Sequence.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_187" = {
+         isa = "PBXFileReference";
+         path = "SerialDispatchQueueScheduler.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_188" = {
+         isa = "PBXFileReference";
+         path = "SerialDisposable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_189" = {
+         isa = "PBXFileReference";
+         path = "ShareReplayScope.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_19" = {
+         isa = "PBXFileReference";
+         path = "InteractiveTransitionAnimation.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_190" = {
+         isa = "PBXFileReference";
+         path = "Single.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_191" = {
+         isa = "PBXFileReference";
+         path = "SingleAssignmentDisposable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_192" = {
+         isa = "PBXFileReference";
+         path = "SingleAsync.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_193" = {
+         isa = "PBXFileReference";
+         path = "Sink.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_194" = {
+         isa = "PBXFileReference";
+         path = "Skip.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_195" = {
+         isa = "PBXFileReference";
+         path = "SkipUntil.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_196" = {
+         isa = "PBXFileReference";
+         path = "SkipWhile.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_197" = {
+         isa = "PBXFileReference";
+         path = "StartWith.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_198" = {
+         isa = "PBXFileReference";
+         path = "SubjectType.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_199" = {
+         isa = "PBXFileReference";
+         path = "SubscribeOn.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_3",
+            "OBJ_4"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_20" = {
+         isa = "PBXFileReference";
+         path = "InterruptibleTransitionAnimation.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_200" = {
+         isa = "PBXFileReference";
+         path = "SubscriptionDisposable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_201" = {
+         isa = "PBXFileReference";
+         path = "SwiftSupport.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_202" = {
+         isa = "PBXFileReference";
+         path = "Switch.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_203" = {
+         isa = "PBXFileReference";
+         path = "SwitchIfEmpty.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_204" = {
+         isa = "PBXFileReference";
+         path = "SynchronizedDisposeType.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_205" = {
+         isa = "PBXFileReference";
+         path = "SynchronizedOnType.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_206" = {
+         isa = "PBXFileReference";
+         path = "SynchronizedUnsubscribeType.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_207" = {
+         isa = "PBXFileReference";
+         path = "TailRecursiveSink.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_208" = {
+         isa = "PBXFileReference";
+         path = "Take.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_209" = {
+         isa = "PBXFileReference";
+         path = "TakeLast.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_21" = {
+         isa = "PBXFileReference";
+         path = "NavigationAnimationDelegate.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_210" = {
+         isa = "PBXFileReference";
+         path = "TakeUntil.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_211" = {
+         isa = "PBXFileReference";
+         path = "TakeWhile.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_212" = {
+         isa = "PBXFileReference";
+         path = "Throttle.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_213" = {
+         isa = "PBXFileReference";
+         path = "Timeout.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_214" = {
+         isa = "PBXFileReference";
+         path = "Timer.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_215" = {
+         isa = "PBXFileReference";
+         path = "ToArray.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_216" = {
+         isa = "PBXFileReference";
+         path = "Using.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_217" = {
+         isa = "PBXFileReference";
+         path = "VirtualTimeConverterType.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_218" = {
+         isa = "PBXFileReference";
+         path = "VirtualTimeScheduler.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_219" = {
+         isa = "PBXFileReference";
+         path = "Window.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_22" = {
+         isa = "PBXFileReference";
+         path = "NavigationCoordinator.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_220" = {
+         isa = "PBXFileReference";
+         path = "WithLatestFrom.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_221" = {
+         isa = "PBXFileReference";
+         path = "Zip+Collection.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_222" = {
+         isa = "PBXFileReference";
+         path = "Zip+arity.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_223" = {
+         isa = "PBXFileReference";
+         path = "Zip.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_224" = {
+         isa = "PBXGroup";
+         children = (
+         );
+         name = "RxTest";
+         path = ".build/checkouts/RxSwift/Sources/RxTest";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_225" = {
+         isa = "PBXFileReference";
+         explicitFileType = "sourcecode.swift";
+         name = "Package.swift";
+         path = "/Users/guilherme.rodrigues/Workspace/grsouza/XCoordinator/.build/checkouts/RxSwift/Package.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_226" = {
+         isa = "PBXGroup";
+         children = (
+            "RxSwift::RxSwift::Product",
+            "XCoordinator::XCoordinatorRx::Product",
+            "XCoordinator::XCoordinator::Product",
+            "XCoordinator::XCoordinatorCombine::Product",
+            "XCoordinator::XCoordinatorTests::Product"
+         );
+         name = "Products";
+         path = "";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "OBJ_23" = {
+         isa = "PBXFileReference";
+         path = "NavigationTransition.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_232" = {
+         isa = "PBXFileReference";
+         path = "Images";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_233" = {
+         isa = "PBXFileReference";
+         path = "docs";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_234" = {
+         isa = "PBXFileReference";
+         path = "scripts";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_235" = {
+         isa = "PBXFileReference";
+         path = "XCoordinator.podspec";
+         sourceTree = "<group>";
+      };
+      "OBJ_236" = {
+         isa = "PBXFileReference";
+         path = "LICENSE";
+         sourceTree = "<group>";
+      };
+      "OBJ_237" = {
+         isa = "PBXFileReference";
+         path = "README.md";
+         sourceTree = "<group>";
+      };
+      "OBJ_239" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_240",
+            "OBJ_241"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_24" = {
+         isa = "PBXFileReference";
+         path = "PageCoordinator.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_240" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "XCoordinator.xcodeproj/RxSwift_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "RxSwift";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "RxSwift";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "3.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_241" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "XCoordinator.xcodeproj/RxSwift_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "RxSwift";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "RxSwift";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "3.0";
+         };
+         name = "Release";
+      };
+      "OBJ_242" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_243",
+            "OBJ_244",
+            "OBJ_245",
+            "OBJ_246",
+            "OBJ_247",
+            "OBJ_248",
+            "OBJ_249",
+            "OBJ_250",
+            "OBJ_251",
+            "OBJ_252",
+            "OBJ_253",
+            "OBJ_254",
+            "OBJ_255",
+            "OBJ_256",
+            "OBJ_257",
+            "OBJ_258",
+            "OBJ_259",
+            "OBJ_260",
+            "OBJ_261",
+            "OBJ_262",
+            "OBJ_263",
+            "OBJ_264",
+            "OBJ_265",
+            "OBJ_266",
+            "OBJ_267",
+            "OBJ_268",
+            "OBJ_269",
+            "OBJ_270",
+            "OBJ_271",
+            "OBJ_272",
+            "OBJ_273",
+            "OBJ_274",
+            "OBJ_275",
+            "OBJ_276",
+            "OBJ_277",
+            "OBJ_278",
+            "OBJ_279",
+            "OBJ_280",
+            "OBJ_281",
+            "OBJ_282",
+            "OBJ_283",
+            "OBJ_284",
+            "OBJ_285",
+            "OBJ_286",
+            "OBJ_287",
+            "OBJ_288",
+            "OBJ_289",
+            "OBJ_290",
+            "OBJ_291",
+            "OBJ_292",
+            "OBJ_293",
+            "OBJ_294",
+            "OBJ_295",
+            "OBJ_296",
+            "OBJ_297",
+            "OBJ_298",
+            "OBJ_299",
+            "OBJ_300",
+            "OBJ_301",
+            "OBJ_302",
+            "OBJ_303",
+            "OBJ_304",
+            "OBJ_305",
+            "OBJ_306",
+            "OBJ_307",
+            "OBJ_308",
+            "OBJ_309",
+            "OBJ_310",
+            "OBJ_311",
+            "OBJ_312",
+            "OBJ_313",
+            "OBJ_314",
+            "OBJ_315",
+            "OBJ_316",
+            "OBJ_317",
+            "OBJ_318",
+            "OBJ_319",
+            "OBJ_320",
+            "OBJ_321",
+            "OBJ_322",
+            "OBJ_323",
+            "OBJ_324",
+            "OBJ_325",
+            "OBJ_326",
+            "OBJ_327",
+            "OBJ_328",
+            "OBJ_329",
+            "OBJ_330",
+            "OBJ_331",
+            "OBJ_332",
+            "OBJ_333",
+            "OBJ_334",
+            "OBJ_335",
+            "OBJ_336",
+            "OBJ_337",
+            "OBJ_338",
+            "OBJ_339",
+            "OBJ_340",
+            "OBJ_341",
+            "OBJ_342",
+            "OBJ_343",
+            "OBJ_344",
+            "OBJ_345",
+            "OBJ_346",
+            "OBJ_347",
+            "OBJ_348",
+            "OBJ_349",
+            "OBJ_350",
+            "OBJ_351",
+            "OBJ_352",
+            "OBJ_353",
+            "OBJ_354",
+            "OBJ_355",
+            "OBJ_356",
+            "OBJ_357",
+            "OBJ_358",
+            "OBJ_359",
+            "OBJ_360",
+            "OBJ_361",
+            "OBJ_362",
+            "OBJ_363",
+            "OBJ_364",
+            "OBJ_365",
+            "OBJ_366",
+            "OBJ_367",
+            "OBJ_368",
+            "OBJ_369",
+            "OBJ_370",
+            "OBJ_371",
+            "OBJ_372",
+            "OBJ_373",
+            "OBJ_374",
+            "OBJ_375",
+            "OBJ_376",
+            "OBJ_377",
+            "OBJ_378",
+            "OBJ_379",
+            "OBJ_380",
+            "OBJ_381",
+            "OBJ_382",
+            "OBJ_383",
+            "OBJ_384",
+            "OBJ_385",
+            "OBJ_386",
+            "OBJ_387",
+            "OBJ_388",
+            "OBJ_389",
+            "OBJ_390",
+            "OBJ_391",
+            "OBJ_392"
+         );
+      };
+      "OBJ_243" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_74";
+      };
+      "OBJ_244" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_75";
+      };
+      "OBJ_245" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_76";
+      };
+      "OBJ_246" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_77";
+      };
+      "OBJ_247" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_78";
+      };
+      "OBJ_248" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_79";
+      };
+      "OBJ_249" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_80";
+      };
+      "OBJ_25" = {
+         isa = "PBXFileReference";
+         path = "PageCoordinatorDataSource.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_250" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_81";
+      };
+      "OBJ_251" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_82";
+      };
+      "OBJ_252" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_83";
+      };
+      "OBJ_253" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_84";
+      };
+      "OBJ_254" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_85";
+      };
+      "OBJ_255" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_86";
+      };
+      "OBJ_256" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_87";
+      };
+      "OBJ_257" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_88";
+      };
+      "OBJ_258" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_89";
+      };
+      "OBJ_259" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_90";
+      };
+      "OBJ_26" = {
+         isa = "PBXFileReference";
+         path = "PageTransition.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_260" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_91";
+      };
+      "OBJ_261" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_92";
+      };
+      "OBJ_262" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_93";
+      };
+      "OBJ_263" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_94";
+      };
+      "OBJ_264" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_95";
+      };
+      "OBJ_265" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_96";
+      };
+      "OBJ_266" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_97";
+      };
+      "OBJ_267" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_98";
+      };
+      "OBJ_268" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_99";
+      };
+      "OBJ_269" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_100";
+      };
+      "OBJ_27" = {
+         isa = "PBXFileReference";
+         path = "Presentable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_270" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_101";
+      };
+      "OBJ_271" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_102";
+      };
+      "OBJ_272" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_103";
+      };
+      "OBJ_273" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_104";
+      };
+      "OBJ_274" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_105";
+      };
+      "OBJ_275" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_106";
+      };
+      "OBJ_276" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_107";
+      };
+      "OBJ_277" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_108";
+      };
+      "OBJ_278" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_109";
+      };
+      "OBJ_279" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_110";
+      };
+      "OBJ_28" = {
+         isa = "PBXFileReference";
+         path = "RedirectionRouter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_280" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_111";
+      };
+      "OBJ_281" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_112";
+      };
+      "OBJ_282" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_113";
+      };
+      "OBJ_283" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_114";
+      };
+      "OBJ_284" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_115";
+      };
+      "OBJ_285" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_116";
+      };
+      "OBJ_286" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_117";
+      };
+      "OBJ_287" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_118";
+      };
+      "OBJ_288" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_119";
+      };
+      "OBJ_289" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_120";
+      };
+      "OBJ_29" = {
+         isa = "PBXFileReference";
+         path = "Route.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_290" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_121";
+      };
+      "OBJ_291" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_122";
+      };
+      "OBJ_292" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_123";
+      };
+      "OBJ_293" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_124";
+      };
+      "OBJ_294" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_125";
+      };
+      "OBJ_295" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_126";
+      };
+      "OBJ_296" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_127";
+      };
+      "OBJ_297" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_128";
+      };
+      "OBJ_298" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_129";
+      };
+      "OBJ_299" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_130";
+      };
+      "OBJ_3" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_OBJC_ARC = "YES";
+            COMBINE_HIDPI_IMAGES = "YES";
+            COPY_PHASE_STRIP = "NO";
+            DEBUG_INFORMATION_FORMAT = "dwarf";
+            DYLIB_INSTALL_NAME_BASE = "@rpath";
+            ENABLE_NS_ASSERTIONS = "YES";
+            GCC_OPTIMIZATION_LEVEL = "0";
+            GCC_PREPROCESSOR_DEFINITIONS = (
+               "$(inherited)",
+               "SWIFT_PACKAGE=1",
+               "DEBUG=1"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            ONLY_ACTIVE_ARCH = "YES";
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-DXcode"
+            );
+            PRODUCT_NAME = "$(TARGET_NAME)";
+            SDKROOT = "macosx";
+            SUPPORTED_PLATFORMS = (
+               "macosx",
+               "iphoneos",
+               "iphonesimulator",
+               "appletvos",
+               "appletvsimulator",
+               "watchos",
+               "watchsimulator"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)",
+               "SWIFT_PACKAGE",
+               "DEBUG"
+            );
+            SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+            USE_HEADERMAP = "NO";
+         };
+         name = "Debug";
+      };
+      "OBJ_30" = {
+         isa = "PBXFileReference";
+         path = "Router.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_300" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_131";
+      };
+      "OBJ_301" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_132";
+      };
+      "OBJ_302" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_133";
+      };
+      "OBJ_303" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_134";
+      };
+      "OBJ_304" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_135";
+      };
+      "OBJ_305" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_136";
+      };
+      "OBJ_306" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_137";
+      };
+      "OBJ_307" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_138";
+      };
+      "OBJ_308" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_139";
+      };
+      "OBJ_309" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_140";
+      };
+      "OBJ_31" = {
+         isa = "PBXFileReference";
+         path = "SplitCoordinator.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_310" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_141";
+      };
+      "OBJ_311" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_142";
+      };
+      "OBJ_312" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_143";
+      };
+      "OBJ_313" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_144";
+      };
+      "OBJ_314" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_145";
+      };
+      "OBJ_315" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_146";
+      };
+      "OBJ_316" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_147";
+      };
+      "OBJ_317" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_148";
+      };
+      "OBJ_318" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_149";
+      };
+      "OBJ_319" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_150";
+      };
+      "OBJ_32" = {
+         isa = "PBXFileReference";
+         path = "SplitTransition.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_320" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_151";
+      };
+      "OBJ_321" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_152";
+      };
+      "OBJ_322" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_153";
+      };
+      "OBJ_323" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_154";
+      };
+      "OBJ_324" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_155";
+      };
+      "OBJ_325" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_156";
+      };
+      "OBJ_326" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_157";
+      };
+      "OBJ_327" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_158";
+      };
+      "OBJ_328" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_159";
+      };
+      "OBJ_329" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_160";
+      };
+      "OBJ_33" = {
+         isa = "PBXFileReference";
+         path = "StaticTransitionAnimation.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_330" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_161";
+      };
+      "OBJ_331" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_162";
+      };
+      "OBJ_332" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_163";
+      };
+      "OBJ_333" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_164";
+      };
+      "OBJ_334" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_165";
+      };
+      "OBJ_335" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_166";
+      };
+      "OBJ_336" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_167";
+      };
+      "OBJ_337" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_168";
+      };
+      "OBJ_338" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_169";
+      };
+      "OBJ_339" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_170";
+      };
+      "OBJ_34" = {
+         isa = "PBXFileReference";
+         path = "StrongRouter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_340" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_171";
+      };
+      "OBJ_341" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_172";
+      };
+      "OBJ_342" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_173";
+      };
+      "OBJ_343" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_174";
+      };
+      "OBJ_344" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_175";
+      };
+      "OBJ_345" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_176";
+      };
+      "OBJ_346" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_177";
+      };
+      "OBJ_347" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_178";
+      };
+      "OBJ_348" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_179";
+      };
+      "OBJ_349" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_180";
+      };
+      "OBJ_35" = {
+         isa = "PBXFileReference";
+         path = "TabBarAnimationDelegate.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_350" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_181";
+      };
+      "OBJ_351" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_182";
+      };
+      "OBJ_352" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_183";
+      };
+      "OBJ_353" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_184";
+      };
+      "OBJ_354" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_185";
+      };
+      "OBJ_355" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_186";
+      };
+      "OBJ_356" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_187";
+      };
+      "OBJ_357" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_188";
+      };
+      "OBJ_358" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_189";
+      };
+      "OBJ_359" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_190";
+      };
+      "OBJ_36" = {
+         isa = "PBXFileReference";
+         path = "TabBarCoordinator.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_360" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_191";
+      };
+      "OBJ_361" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_192";
+      };
+      "OBJ_362" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_193";
+      };
+      "OBJ_363" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_194";
+      };
+      "OBJ_364" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_195";
+      };
+      "OBJ_365" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_196";
+      };
+      "OBJ_366" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_197";
+      };
+      "OBJ_367" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_198";
+      };
+      "OBJ_368" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_199";
+      };
+      "OBJ_369" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_200";
+      };
+      "OBJ_37" = {
+         isa = "PBXFileReference";
+         path = "TabBarTransition.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_370" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_201";
+      };
+      "OBJ_371" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_202";
+      };
+      "OBJ_372" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_203";
+      };
+      "OBJ_373" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_204";
+      };
+      "OBJ_374" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_205";
+      };
+      "OBJ_375" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_206";
+      };
+      "OBJ_376" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_207";
+      };
+      "OBJ_377" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_208";
+      };
+      "OBJ_378" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_209";
+      };
+      "OBJ_379" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_210";
+      };
+      "OBJ_38" = {
+         isa = "PBXFileReference";
+         path = "Transition+Init.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_380" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_211";
+      };
+      "OBJ_381" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_212";
+      };
+      "OBJ_382" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_213";
+      };
+      "OBJ_383" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_214";
+      };
+      "OBJ_384" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_215";
+      };
+      "OBJ_385" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_216";
+      };
+      "OBJ_386" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_217";
+      };
+      "OBJ_387" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_218";
+      };
+      "OBJ_388" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_219";
+      };
+      "OBJ_389" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_220";
+      };
+      "OBJ_39" = {
+         isa = "PBXFileReference";
+         path = "Transition.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_390" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_221";
+      };
+      "OBJ_391" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_222";
+      };
+      "OBJ_392" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_223";
+      };
+      "OBJ_393" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
+      };
+      "OBJ_395" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_396",
+            "OBJ_397"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_396" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "5",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "5.0.0"
+            );
+            SWIFT_VERSION = "5.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_397" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "5",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "5.0.0"
+            );
+            SWIFT_VERSION = "5.0";
+         };
+         name = "Release";
+      };
+      "OBJ_398" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_399"
+         );
+      };
+      "OBJ_399" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_225";
+      };
+      "OBJ_4" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_OBJC_ARC = "YES";
+            COMBINE_HIDPI_IMAGES = "YES";
+            COPY_PHASE_STRIP = "YES";
+            DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+            DYLIB_INSTALL_NAME_BASE = "@rpath";
+            GCC_OPTIMIZATION_LEVEL = "s";
+            GCC_PREPROCESSOR_DEFINITIONS = (
+               "$(inherited)",
+               "SWIFT_PACKAGE=1"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-DXcode"
+            );
+            PRODUCT_NAME = "$(TARGET_NAME)";
+            SDKROOT = "macosx";
+            SUPPORTED_PLATFORMS = (
+               "macosx",
+               "iphoneos",
+               "iphonesimulator",
+               "appletvos",
+               "appletvsimulator",
+               "watchos",
+               "watchsimulator"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)",
+               "SWIFT_PACKAGE"
+            );
+            SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+            USE_HEADERMAP = "NO";
+         };
+         name = "Release";
+      };
+      "OBJ_40" = {
+         isa = "PBXFileReference";
+         path = "TransitionAnimation.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_401" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_402",
+            "OBJ_403"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_402" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "XCoordinator.xcodeproj/XCoordinator_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "XCoordinator";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "XCoordinator";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_403" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "XCoordinator.xcodeproj/XCoordinator_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "XCoordinator";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "XCoordinator";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Release";
+      };
+      "OBJ_404" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_405",
+            "OBJ_406",
+            "OBJ_407",
+            "OBJ_408",
+            "OBJ_409",
+            "OBJ_410",
+            "OBJ_411",
+            "OBJ_412",
+            "OBJ_413",
+            "OBJ_414",
+            "OBJ_415",
+            "OBJ_416",
+            "OBJ_417",
+            "OBJ_418",
+            "OBJ_419",
+            "OBJ_420",
+            "OBJ_421",
+            "OBJ_422",
+            "OBJ_423",
+            "OBJ_424",
+            "OBJ_425",
+            "OBJ_426",
+            "OBJ_427",
+            "OBJ_428",
+            "OBJ_429",
+            "OBJ_430",
+            "OBJ_431",
+            "OBJ_432",
+            "OBJ_433",
+            "OBJ_434",
+            "OBJ_435",
+            "OBJ_436",
+            "OBJ_437",
+            "OBJ_438",
+            "OBJ_439",
+            "OBJ_440",
+            "OBJ_441",
+            "OBJ_442",
+            "OBJ_443",
+            "OBJ_444",
+            "OBJ_445",
+            "OBJ_446",
+            "OBJ_447",
+            "OBJ_448",
+            "OBJ_449"
+         );
+      };
+      "OBJ_405" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_9";
+      };
+      "OBJ_406" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_10";
+      };
+      "OBJ_407" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_11";
+      };
+      "OBJ_408" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_12";
+      };
+      "OBJ_409" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_13";
+      };
+      "OBJ_41" = {
+         isa = "PBXFileReference";
+         path = "TransitionOptions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_410" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_14";
+      };
+      "OBJ_411" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_15";
+      };
+      "OBJ_412" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_16";
+      };
+      "OBJ_413" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_17";
+      };
+      "OBJ_414" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_18";
+      };
+      "OBJ_415" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_19";
+      };
+      "OBJ_416" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_20";
+      };
+      "OBJ_417" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_21";
+      };
+      "OBJ_418" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_22";
+      };
+      "OBJ_419" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_23";
+      };
+      "OBJ_42" = {
+         isa = "PBXFileReference";
+         path = "TransitionPerformer.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_420" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_24";
+      };
+      "OBJ_421" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_25";
+      };
+      "OBJ_422" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_26";
+      };
+      "OBJ_423" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_27";
+      };
+      "OBJ_424" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_28";
+      };
+      "OBJ_425" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_29";
+      };
+      "OBJ_426" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_30";
+      };
+      "OBJ_427" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_31";
+      };
+      "OBJ_428" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_32";
+      };
+      "OBJ_429" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_33";
+      };
+      "OBJ_43" = {
+         isa = "PBXFileReference";
+         path = "TransitionProtocol.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_430" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_34";
+      };
+      "OBJ_431" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_35";
+      };
+      "OBJ_432" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_36";
+      };
+      "OBJ_433" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_37";
+      };
+      "OBJ_434" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_38";
+      };
+      "OBJ_435" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_39";
+      };
+      "OBJ_436" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_40";
+      };
+      "OBJ_437" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_41";
+      };
+      "OBJ_438" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_42";
+      };
+      "OBJ_439" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_43";
+      };
+      "OBJ_44" = {
+         isa = "PBXFileReference";
+         path = "UINavigationController+Transition.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_440" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_44";
+      };
+      "OBJ_441" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_45";
+      };
+      "OBJ_442" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_46";
+      };
+      "OBJ_443" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_47";
+      };
+      "OBJ_444" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_48";
+      };
+      "OBJ_445" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_49";
+      };
+      "OBJ_446" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_50";
+      };
+      "OBJ_447" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_51";
+      };
+      "OBJ_448" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_52";
+      };
+      "OBJ_449" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_53";
+      };
+      "OBJ_45" = {
+         isa = "PBXFileReference";
+         path = "UIPageViewController+Transition.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_450" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
+      };
+      "OBJ_452" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_453",
+            "OBJ_454"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_453" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "XCoordinator.xcodeproj/XCoordinatorCombine_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "XCoordinatorCombine";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "XCoordinatorCombine";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_454" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "XCoordinator.xcodeproj/XCoordinatorCombine_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "XCoordinatorCombine";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "XCoordinatorCombine";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Release";
+      };
+      "OBJ_455" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_456"
+         );
+      };
+      "OBJ_456" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_55";
+      };
+      "OBJ_457" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_458"
+         );
+      };
+      "OBJ_458" = {
+         isa = "PBXBuildFile";
+         fileRef = "XCoordinator::XCoordinator::Product";
+      };
+      "OBJ_459" = {
+         isa = "PBXTargetDependency";
+         target = "XCoordinator::XCoordinator";
+      };
+      "OBJ_46" = {
+         isa = "PBXFileReference";
+         path = "UITabBarController+Transition.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_461" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_462",
+            "OBJ_463"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_462" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "5",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "5.1.0"
+            );
+            SWIFT_VERSION = "5.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_463" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "5",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
+               "-package-description-version",
+               "5.1.0"
+            );
+            SWIFT_VERSION = "5.0";
+         };
+         name = "Release";
+      };
+      "OBJ_464" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_465"
+         );
+      };
+      "OBJ_465" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_6";
+      };
+      "OBJ_467" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_468",
+            "OBJ_469"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_468" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+         };
+         name = "Debug";
+      };
+      "OBJ_469" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+         };
+         name = "Release";
+      };
+      "OBJ_47" = {
+         isa = "PBXFileReference";
+         path = "UIView+Store.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_470" = {
+         isa = "PBXTargetDependency";
+         target = "XCoordinator::XCoordinatorTests";
+      };
+      "OBJ_473" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_474",
+            "OBJ_475"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_474" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "XCoordinator.xcodeproj/XCoordinatorRx_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "XCoordinatorRx";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "XCoordinatorRx";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_475" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "XCoordinator.xcodeproj/XCoordinatorRx_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "XCoordinatorRx";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "XCoordinatorRx";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Release";
+      };
+      "OBJ_476" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_477"
+         );
+      };
+      "OBJ_477" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_57";
+      };
+      "OBJ_478" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_479",
+            "OBJ_480"
+         );
+      };
+      "OBJ_479" = {
+         isa = "PBXBuildFile";
+         fileRef = "RxSwift::RxSwift::Product";
+      };
+      "OBJ_48" = {
+         isa = "PBXFileReference";
+         path = "UIViewController+Transition.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_480" = {
+         isa = "PBXBuildFile";
+         fileRef = "XCoordinator::XCoordinator::Product";
+      };
+      "OBJ_481" = {
+         isa = "PBXTargetDependency";
+         target = "RxSwift::RxSwift";
+      };
+      "OBJ_482" = {
+         isa = "PBXTargetDependency";
+         target = "XCoordinator::XCoordinator";
+      };
+      "OBJ_483" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_484",
+            "OBJ_485"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_484" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "XCoordinator.xcodeproj/XCoordinatorTests_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "@loader_path/../Frameworks",
+               "@loader_path/Frameworks"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "XCoordinatorTests";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_485" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "XCoordinator.xcodeproj/XCoordinatorTests_Info.plist";
+            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "@loader_path/../Frameworks",
+               "@loader_path/Frameworks"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "5.0";
+            TARGET_NAME = "XCoordinatorTests";
+            TVOS_DEPLOYMENT_TARGET = "9.0";
+            WATCHOS_DEPLOYMENT_TARGET = "2.0";
+         };
+         name = "Release";
+      };
+      "OBJ_486" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_487",
+            "OBJ_488",
+            "OBJ_489",
+            "OBJ_490",
+            "OBJ_491",
+            "OBJ_492"
+         );
+      };
+      "OBJ_487" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_61";
+      };
+      "OBJ_488" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_62";
+      };
+      "OBJ_489" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_63";
+      };
+      "OBJ_49" = {
+         isa = "PBXFileReference";
+         path = "UnownedErased+Router.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_490" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_64";
+      };
+      "OBJ_491" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_65";
+      };
+      "OBJ_492" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_66";
+      };
+      "OBJ_493" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_494",
+            "OBJ_495",
+            "OBJ_496"
+         );
+      };
+      "OBJ_494" = {
+         isa = "PBXBuildFile";
+         fileRef = "XCoordinator::XCoordinatorRx::Product";
+      };
+      "OBJ_495" = {
+         isa = "PBXBuildFile";
+         fileRef = "RxSwift::RxSwift::Product";
+      };
+      "OBJ_496" = {
+         isa = "PBXBuildFile";
+         fileRef = "XCoordinator::XCoordinator::Product";
+      };
+      "OBJ_497" = {
+         isa = "PBXTargetDependency";
+         target = "XCoordinator::XCoordinatorRx";
+      };
+      "OBJ_498" = {
+         isa = "PBXTargetDependency";
+         target = "RxSwift::RxSwift";
+      };
+      "OBJ_499" = {
+         isa = "PBXTargetDependency";
+         target = "XCoordinator::XCoordinator";
+      };
+      "OBJ_5" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_6",
+            "OBJ_7",
+            "OBJ_58",
+            "OBJ_67",
+            "OBJ_226",
+            "OBJ_232",
+            "OBJ_233",
+            "OBJ_234",
+            "OBJ_235",
+            "OBJ_236",
+            "OBJ_237"
+         );
+         path = "";
+         sourceTree = "<group>";
+      };
+      "OBJ_50" = {
+         isa = "PBXFileReference";
+         path = "UnownedErased.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_51" = {
+         isa = "PBXFileReference";
+         path = "ViewCoordinator.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_52" = {
+         isa = "PBXFileReference";
+         path = "WeakErased+Router.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_53" = {
+         isa = "PBXFileReference";
+         path = "WeakErased.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_54" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_55"
+         );
+         name = "XCoordinatorCombine";
+         path = "Sources/XCoordinatorCombine";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_55" = {
+         isa = "PBXFileReference";
+         path = "Router+Combine.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_56" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_57"
+         );
+         name = "XCoordinatorRx";
+         path = "Sources/XCoordinatorRx";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_57" = {
+         isa = "PBXFileReference";
+         path = "Router+Rx.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_58" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_59"
+         );
+         name = "Tests";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_59" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_60",
+            "OBJ_61",
+            "OBJ_62",
+            "OBJ_63",
+            "OBJ_64",
+            "OBJ_65",
+            "OBJ_66"
+         );
+         name = "XCoordinatorTests";
+         path = "Tests/XCoordinatorTests";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_6" = {
+         isa = "PBXFileReference";
+         explicitFileType = "sourcecode.swift";
+         path = "Package.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_60" = {
+         isa = "PBXFileReference";
+         path = "XCoordinatorTests.xctestplan";
+         sourceTree = "<group>";
+      };
+      "OBJ_61" = {
+         isa = "PBXFileReference";
+         path = "AnimationTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_62" = {
+         isa = "PBXFileReference";
+         path = "TestAnimation.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_63" = {
+         isa = "PBXFileReference";
+         path = "TestRoute.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_64" = {
+         isa = "PBXFileReference";
+         path = "TransitionTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_65" = {
+         isa = "PBXFileReference";
+         path = "XCTestManifests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_66" = {
+         isa = "PBXFileReference";
+         path = "XCText+Extras.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_67" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_68"
+         );
+         name = "Dependencies";
+         path = "";
+         sourceTree = "<group>";
+      };
+      "OBJ_68" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_69",
+            "OBJ_70",
+            "OBJ_71",
+            "OBJ_72",
+            "OBJ_73",
+            "OBJ_224",
+            "OBJ_225"
+         );
+         name = "RxSwift 5.1.1";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_69" = {
+         isa = "PBXGroup";
+         children = (
+         );
+         name = "RxBlocking";
+         path = ".build/checkouts/RxSwift/Sources/RxBlocking";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_7" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_8",
+            "OBJ_54",
+            "OBJ_56"
+         );
+         name = "Sources";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_70" = {
+         isa = "PBXGroup";
+         children = (
+         );
+         name = "RxCocoa";
+         path = ".build/checkouts/RxSwift/Sources/RxCocoa";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_71" = {
+         isa = "PBXGroup";
+         children = (
+         );
+         name = "RxCocoaRuntime";
+         path = ".build/checkouts/RxSwift/Sources/RxCocoaRuntime";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_72" = {
+         isa = "PBXGroup";
+         children = (
+         );
+         name = "RxRelay";
+         path = ".build/checkouts/RxSwift/Sources/RxRelay";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_73" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_74",
+            "OBJ_75",
+            "OBJ_76",
+            "OBJ_77",
+            "OBJ_78",
+            "OBJ_79",
+            "OBJ_80",
+            "OBJ_81",
+            "OBJ_82",
+            "OBJ_83",
+            "OBJ_84",
+            "OBJ_85",
+            "OBJ_86",
+            "OBJ_87",
+            "OBJ_88",
+            "OBJ_89",
+            "OBJ_90",
+            "OBJ_91",
+            "OBJ_92",
+            "OBJ_93",
+            "OBJ_94",
+            "OBJ_95",
+            "OBJ_96",
+            "OBJ_97",
+            "OBJ_98",
+            "OBJ_99",
+            "OBJ_100",
+            "OBJ_101",
+            "OBJ_102",
+            "OBJ_103",
+            "OBJ_104",
+            "OBJ_105",
+            "OBJ_106",
+            "OBJ_107",
+            "OBJ_108",
+            "OBJ_109",
+            "OBJ_110",
+            "OBJ_111",
+            "OBJ_112",
+            "OBJ_113",
+            "OBJ_114",
+            "OBJ_115",
+            "OBJ_116",
+            "OBJ_117",
+            "OBJ_118",
+            "OBJ_119",
+            "OBJ_120",
+            "OBJ_121",
+            "OBJ_122",
+            "OBJ_123",
+            "OBJ_124",
+            "OBJ_125",
+            "OBJ_126",
+            "OBJ_127",
+            "OBJ_128",
+            "OBJ_129",
+            "OBJ_130",
+            "OBJ_131",
+            "OBJ_132",
+            "OBJ_133",
+            "OBJ_134",
+            "OBJ_135",
+            "OBJ_136",
+            "OBJ_137",
+            "OBJ_138",
+            "OBJ_139",
+            "OBJ_140",
+            "OBJ_141",
+            "OBJ_142",
+            "OBJ_143",
+            "OBJ_144",
+            "OBJ_145",
+            "OBJ_146",
+            "OBJ_147",
+            "OBJ_148",
+            "OBJ_149",
+            "OBJ_150",
+            "OBJ_151",
+            "OBJ_152",
+            "OBJ_153",
+            "OBJ_154",
+            "OBJ_155",
+            "OBJ_156",
+            "OBJ_157",
+            "OBJ_158",
+            "OBJ_159",
+            "OBJ_160",
+            "OBJ_161",
+            "OBJ_162",
+            "OBJ_163",
+            "OBJ_164",
+            "OBJ_165",
+            "OBJ_166",
+            "OBJ_167",
+            "OBJ_168",
+            "OBJ_169",
+            "OBJ_170",
+            "OBJ_171",
+            "OBJ_172",
+            "OBJ_173",
+            "OBJ_174",
+            "OBJ_175",
+            "OBJ_176",
+            "OBJ_177",
+            "OBJ_178",
+            "OBJ_179",
+            "OBJ_180",
+            "OBJ_181",
+            "OBJ_182",
+            "OBJ_183",
+            "OBJ_184",
+            "OBJ_185",
+            "OBJ_186",
+            "OBJ_187",
+            "OBJ_188",
+            "OBJ_189",
+            "OBJ_190",
+            "OBJ_191",
+            "OBJ_192",
+            "OBJ_193",
+            "OBJ_194",
+            "OBJ_195",
+            "OBJ_196",
+            "OBJ_197",
+            "OBJ_198",
+            "OBJ_199",
+            "OBJ_200",
+            "OBJ_201",
+            "OBJ_202",
+            "OBJ_203",
+            "OBJ_204",
+            "OBJ_205",
+            "OBJ_206",
+            "OBJ_207",
+            "OBJ_208",
+            "OBJ_209",
+            "OBJ_210",
+            "OBJ_211",
+            "OBJ_212",
+            "OBJ_213",
+            "OBJ_214",
+            "OBJ_215",
+            "OBJ_216",
+            "OBJ_217",
+            "OBJ_218",
+            "OBJ_219",
+            "OBJ_220",
+            "OBJ_221",
+            "OBJ_222",
+            "OBJ_223"
+         );
+         name = "RxSwift";
+         path = ".build/checkouts/RxSwift/Sources/RxSwift";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_74" = {
+         isa = "PBXFileReference";
+         path = "AddRef.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_75" = {
+         isa = "PBXFileReference";
+         path = "Amb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_76" = {
+         isa = "PBXFileReference";
+         path = "AnonymousDisposable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_77" = {
+         isa = "PBXFileReference";
+         path = "AnonymousObserver.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_78" = {
+         isa = "PBXFileReference";
+         path = "AnyObserver.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_79" = {
+         isa = "PBXFileReference";
+         path = "AsMaybe.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_8" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_9",
+            "OBJ_10",
+            "OBJ_11",
+            "OBJ_12",
+            "OBJ_13",
+            "OBJ_14",
+            "OBJ_15",
+            "OBJ_16",
+            "OBJ_17",
+            "OBJ_18",
+            "OBJ_19",
+            "OBJ_20",
+            "OBJ_21",
+            "OBJ_22",
+            "OBJ_23",
+            "OBJ_24",
+            "OBJ_25",
+            "OBJ_26",
+            "OBJ_27",
+            "OBJ_28",
+            "OBJ_29",
+            "OBJ_30",
+            "OBJ_31",
+            "OBJ_32",
+            "OBJ_33",
+            "OBJ_34",
+            "OBJ_35",
+            "OBJ_36",
+            "OBJ_37",
+            "OBJ_38",
+            "OBJ_39",
+            "OBJ_40",
+            "OBJ_41",
+            "OBJ_42",
+            "OBJ_43",
+            "OBJ_44",
+            "OBJ_45",
+            "OBJ_46",
+            "OBJ_47",
+            "OBJ_48",
+            "OBJ_49",
+            "OBJ_50",
+            "OBJ_51",
+            "OBJ_52",
+            "OBJ_53"
+         );
+         name = "XCoordinator";
+         path = "Sources/XCoordinator";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_80" = {
+         isa = "PBXFileReference";
+         path = "AsSingle.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_81" = {
+         isa = "PBXFileReference";
+         path = "AsyncLock.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_82" = {
+         isa = "PBXFileReference";
+         path = "AsyncSubject.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_83" = {
+         isa = "PBXFileReference";
+         path = "AtomicInt.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_84" = {
+         isa = "PBXFileReference";
+         path = "Bag+Rx.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_85" = {
+         isa = "PBXFileReference";
+         path = "Bag.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_86" = {
+         isa = "PBXFileReference";
+         path = "BehaviorSubject.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_87" = {
+         isa = "PBXFileReference";
+         path = "BinaryDisposable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_88" = {
+         isa = "PBXFileReference";
+         path = "BooleanDisposable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_89" = {
+         isa = "PBXFileReference";
+         path = "Buffer.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_9" = {
+         isa = "PBXFileReference";
+         path = "Animation.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_90" = {
+         isa = "PBXFileReference";
+         path = "Cancelable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_91" = {
+         isa = "PBXFileReference";
+         path = "Catch.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_92" = {
+         isa = "PBXFileReference";
+         path = "CombineLatest+Collection.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_93" = {
+         isa = "PBXFileReference";
+         path = "CombineLatest+arity.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_94" = {
+         isa = "PBXFileReference";
+         path = "CombineLatest.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_95" = {
+         isa = "PBXFileReference";
+         path = "CompactMap.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_96" = {
+         isa = "PBXFileReference";
+         path = "Completable+AndThen.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_97" = {
+         isa = "PBXFileReference";
+         path = "Completable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_98" = {
+         isa = "PBXFileReference";
+         path = "CompositeDisposable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_99" = {
+         isa = "PBXFileReference";
+         path = "Concat.swift";
+         sourceTree = "<group>";
+      };
+      "RxSwift::RxSwift" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_239";
+         buildPhases = (
+            "OBJ_242",
+            "OBJ_393"
+         );
+         dependencies = (
+         );
+         name = "RxSwift";
+         productName = "RxSwift";
+         productReference = "RxSwift::RxSwift::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "RxSwift::RxSwift::Product" = {
+         isa = "PBXFileReference";
+         path = "RxSwift.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "RxSwift::SwiftPMPackageDescription" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_395";
+         buildPhases = (
+            "OBJ_398"
+         );
+         dependencies = (
+         );
+         name = "RxSwiftPackageDescription";
+         productName = "RxSwiftPackageDescription";
+         productType = "com.apple.product-type.framework";
+      };
+      "XCoordinator::SwiftPMPackageDescription" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_461";
+         buildPhases = (
+            "OBJ_464"
+         );
+         dependencies = (
+         );
+         name = "XCoordinatorPackageDescription";
+         productName = "XCoordinatorPackageDescription";
+         productType = "com.apple.product-type.framework";
+      };
+      "XCoordinator::XCoordinator" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_401";
+         buildPhases = (
+            "OBJ_404",
+            "OBJ_450"
+         );
+         dependencies = (
+         );
+         name = "XCoordinator";
+         productName = "XCoordinator";
+         productReference = "XCoordinator::XCoordinator::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "XCoordinator::XCoordinator::Product" = {
+         isa = "PBXFileReference";
+         path = "XCoordinator.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "XCoordinator::XCoordinatorCombine" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_452";
+         buildPhases = (
+            "OBJ_455",
+            "OBJ_457"
+         );
+         dependencies = (
+            "OBJ_459"
+         );
+         name = "XCoordinatorCombine";
+         productName = "XCoordinatorCombine";
+         productReference = "XCoordinator::XCoordinatorCombine::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "XCoordinator::XCoordinatorCombine::Product" = {
+         isa = "PBXFileReference";
+         path = "XCoordinatorCombine.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "XCoordinator::XCoordinatorPackageTests::ProductTarget" = {
+         isa = "PBXAggregateTarget";
+         buildConfigurationList = "OBJ_467";
+         buildPhases = (
+         );
+         dependencies = (
+            "OBJ_470"
+         );
+         name = "XCoordinatorPackageTests";
+         productName = "XCoordinatorPackageTests";
+      };
+      "XCoordinator::XCoordinatorRx" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_473";
+         buildPhases = (
+            "OBJ_476",
+            "OBJ_478"
+         );
+         dependencies = (
+            "OBJ_481",
+            "OBJ_482"
+         );
+         name = "XCoordinatorRx";
+         productName = "XCoordinatorRx";
+         productReference = "XCoordinator::XCoordinatorRx::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "XCoordinator::XCoordinatorRx::Product" = {
+         isa = "PBXFileReference";
+         path = "XCoordinatorRx.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "XCoordinator::XCoordinatorTests" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_483";
+         buildPhases = (
+            "OBJ_486",
+            "OBJ_493"
+         );
+         dependencies = (
+            "OBJ_497",
+            "OBJ_498",
+            "OBJ_499"
+         );
+         name = "XCoordinatorTests";
+         productName = "XCoordinatorTests";
+         productReference = "XCoordinator::XCoordinatorTests::Product";
+         productType = "com.apple.product-type.bundle.unit-test";
+      };
+      "XCoordinator::XCoordinatorTests::Product" = {
+         isa = "PBXFileReference";
+         path = "XCoordinatorTests.xctest";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+   };
+   rootObject = "OBJ_1";
 }

--- a/XCoordinator.xcodeproj/xcshareddata/xcschemes/XCoordinator-Package.xcscheme
+++ b/XCoordinator.xcodeproj/xcshareddata/xcschemes/XCoordinator-Package.xcscheme
@@ -1,96 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Scheme
-   LastUpgradeVersion = "1130"
-   version = "1.3">
-   <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "XCoordinator::XCoordinator"
-               BuildableName = "XCoordinator.framework"
-               BlueprintName = "XCoordinator"
-               ReferencedContainer = "container:XCoordinator.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "XCoordinator::XCoordinatorCombine"
-               BuildableName = "XCoordinatorCombine.framework"
-               BlueprintName = "XCoordinatorCombine"
-               ReferencedContainer = "container:XCoordinator.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "XCoordinator::XCoordinatorRx"
-               BuildableName = "XCoordinatorRx.framework"
-               BlueprintName = "XCoordinatorRx"
-               ReferencedContainer = "container:XCoordinator.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
-   </BuildAction>
-   <TestAction
-      buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "XCoordinator::XCoordinatorTests"
-               BuildableName = "XCoordinatorTests.xctest"
-               BlueprintName = "XCoordinatorTests"
-               ReferencedContainer = "container:XCoordinator.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
-   </TestAction>
-   <LaunchAction
-      buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      launchStyle = "0"
-      useCustomWorkingDirectory = "NO"
-      ignoresPersistentStateOnLaunch = "NO"
-      debugDocumentVersioning = "YES"
-      debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
-   </LaunchAction>
-   <ProfileAction
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      savedToolIdentifier = ""
-      useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES">
-   </ProfileAction>
-   <AnalyzeAction
-      buildConfiguration = "Debug">
-   </AnalyzeAction>
-   <ArchiveAction
-      buildConfiguration = "Release"
-      revealArchiveInOrganizer = "YES">
-   </ArchiveAction>
+<Scheme LastUpgradeVersion = "9999" version = "1.3">
+  <BuildAction parallelizeBuildables = "YES" buildImplicitDependencies = "YES">
+    <BuildActionEntries>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'lib$(TARGET_NAME)'"
+          BlueprintName = "XCoordinatorCombine"
+          ReferencedContainer = "container:XCoordinator.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'lib$(TARGET_NAME)'"
+          BlueprintName = "XCoordinator"
+          ReferencedContainer = "container:XCoordinator.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'lib$(TARGET_NAME)'"
+          BlueprintName = "XCoordinatorRx"
+          ReferencedContainer = "container:XCoordinator.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+    </BuildActionEntries>
+  </BuildAction>
+  <TestAction
+    buildConfiguration = "Debug"
+    selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+    selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+    shouldUseLaunchSchemeArgsEnv = "YES"
+    codeCoverageEnabled = "YES">
+    <Testables>
+        <TestableReference
+          skipped = "NO">
+          <BuildableReference
+            BuildableIdentifier = "primary"
+            BuildableName = "'$(TARGET_NAME)'"
+            BlueprintName = "XCoordinatorTests"
+            ReferencedContainer = "container:XCoordinator.xcodeproj">
+          </BuildableReference>
+        </TestableReference>
+    </Testables>
+  </TestAction>
 </Scheme>

--- a/XCoordinator.xcodeproj/xcshareddata/xcschemes/XCoordinator-Package.xcscheme
+++ b/XCoordinator.xcodeproj/xcshareddata/xcschemes/XCoordinator-Package.xcscheme
@@ -1,49 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Scheme LastUpgradeVersion = "9999" version = "1.3">
-  <BuildAction parallelizeBuildables = "YES" buildImplicitDependencies = "YES">
-    <BuildActionEntries>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "XCoordinatorCombine"
-          ReferencedContainer = "container:XCoordinator.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "XCoordinator"
-          ReferencedContainer = "container:XCoordinator.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "XCoordinatorRx"
-          ReferencedContainer = "container:XCoordinator.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-    </BuildActionEntries>
-  </BuildAction>
-  <TestAction
-    buildConfiguration = "Debug"
-    selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-    selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-    shouldUseLaunchSchemeArgsEnv = "YES"
-    codeCoverageEnabled = "YES">
-    <Testables>
-        <TestableReference
-          skipped = "NO">
-          <BuildableReference
-            BuildableIdentifier = "primary"
-            BuildableName = "'$(TARGET_NAME)'"
-            BlueprintName = "XCoordinatorTests"
-            ReferencedContainer = "container:XCoordinator.xcodeproj">
-          </BuildableReference>
-        </TestableReference>
-    </Testables>
-  </TestAction>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XCoordinator::XCoordinatorCombine"
+               BuildableName = "XCoordinatorCombine.framework"
+               BlueprintName = "XCoordinatorCombine"
+               ReferencedContainer = "container:XCoordinator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XCoordinator::XCoordinator"
+               BuildableName = "XCoordinator.framework"
+               BlueprintName = "XCoordinator"
+               ReferencedContainer = "container:XCoordinator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XCoordinator::XCoordinatorRx"
+               BuildableName = "XCoordinatorRx.framework"
+               BlueprintName = "XCoordinatorRx"
+               ReferencedContainer = "container:XCoordinator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XCoordinator::XCoordinatorTests"
+               BuildableName = "XCoordinatorTests.xctest"
+               BlueprintName = "XCoordinatorTests"
+               ReferencedContainer = "container:XCoordinator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
 </Scheme>


### PR DESCRIPTION
Hi.

I'm using this framework through Carthage and I had a problem during archive due the missing of `CURRENT_PROJECT_VERSION` inside the framework's Info.plist file.

This PR fixes this issue and also updates RxSwift to latest version.