### PR TITLE
Remove assertion for nil interactivePopGestureRecognizerDelegate

### DIFF
--- a/Sources/XCoordinator/NavigationAnimationDelegate.swift
+++ b/Sources/XCoordinator/NavigationAnimationDelegate.swift
@@ -182,6 +182,10 @@ extension NavigationAnimationDelegate: UIGestureRecognizerDelegate {
         case navigationController?.interactivePopGestureRecognizer:
             let delegateAction = NavigationAnimationDelegate.interactivePopGestureRecognizerDelegateAction
 
+            if interactivePopGestureRecognizerDelegate == nil {
+                return true
+            }
+
             guard let delegate = interactivePopGestureRecognizerDelegate,
                 delegate.responds(to: delegateAction) else {
                     // swiftlint:disable:next line_length

--- a/Sources/XCoordinator/NavigationAnimationDelegate.swift
+++ b/Sources/XCoordinator/NavigationAnimationDelegate.swift
@@ -188,11 +188,11 @@ extension NavigationAnimationDelegate: UIGestureRecognizerDelegate {
                     return false
             }
 
-            gestureRecognizer.removeTarget(nil, action: nil)
-
             if resetPopAnimation() != nil {
+                gestureRecognizer.removeTarget(nil, action: nil)
                 gestureRecognizer.addTarget(self, action: #selector(handleInteractivePopGestureRecognizer(_:)))
             } else if let interactivePopGestureRecognizerDelegate = interactivePopGestureRecognizerDelegate {
+                gestureRecognizer.removeTarget(nil, action: nil)
                 gestureRecognizer.addTarget(interactivePopGestureRecognizerDelegate, action: delegateAction)
             }
             return (navigationController?.viewControllers.count ?? 0) > 1

--- a/Sources/XCoordinator/NavigationAnimationDelegate.swift
+++ b/Sources/XCoordinator/NavigationAnimationDelegate.swift
@@ -182,17 +182,18 @@ extension NavigationAnimationDelegate: UIGestureRecognizerDelegate {
         case navigationController?.interactivePopGestureRecognizer:
             let delegateAction = NavigationAnimationDelegate.interactivePopGestureRecognizerDelegateAction
 
+            guard interactivePopGestureRecognizerDelegate?.responds(to: delegateAction) ?? true else {
+                    // swiftlint:disable:next line_length
+                    assertionFailure("Please don't set a custom delegate on \(UINavigationController.self).\(#selector(getter: UINavigationController.interactivePopGestureRecognizer)).")
+                    return false
+            }
+
             gestureRecognizer.removeTarget(nil, action: nil)
 
             if resetPopAnimation() != nil {
                 gestureRecognizer.addTarget(self, action: #selector(handleInteractivePopGestureRecognizer(_:)))
-            } else if let delegate = interactivePopGestureRecognizerDelegate {
-                if delegate.responds(to: delegateAction) {
-                    gestureRecognizer.addTarget(delegate, action: delegateAction)
-                } else {
-                    assertionFailure("Please don't set a custom delegate on \(UINavigationController.self).\(#selector(getter: UINavigationController.interactivePopGestureRecognizer)).")
-                    return false
-                }
+            } else if let interactivePopGestureRecognizerDelegate = interactivePopGestureRecognizerDelegate {
+                gestureRecognizer.addTarget(interactivePopGestureRecognizerDelegate, action: delegateAction)
             }
             return (navigationController?.viewControllers.count ?? 0) > 1
         default:

--- a/Sources/XCoordinator/NavigationAnimationDelegate.swift
+++ b/Sources/XCoordinator/NavigationAnimationDelegate.swift
@@ -182,23 +182,17 @@ extension NavigationAnimationDelegate: UIGestureRecognizerDelegate {
         case navigationController?.interactivePopGestureRecognizer:
             let delegateAction = NavigationAnimationDelegate.interactivePopGestureRecognizerDelegateAction
 
-            if interactivePopGestureRecognizerDelegate == nil {
-                return true
-            }
-
-            guard let delegate = interactivePopGestureRecognizerDelegate,
-                delegate.responds(to: delegateAction) else {
-                    // swiftlint:disable:next line_length
-                    assertionFailure("Please don't set a custom delegate on \(UINavigationController.self).\(#selector(getter: UINavigationController.interactivePopGestureRecognizer)).")
-                    return false
-            }
-
             gestureRecognizer.removeTarget(nil, action: nil)
 
             if resetPopAnimation() != nil {
                 gestureRecognizer.addTarget(self, action: #selector(handleInteractivePopGestureRecognizer(_:)))
-            } else {
-                gestureRecognizer.addTarget(delegate, action: delegateAction)
+            } else if let delegate = interactivePopGestureRecognizerDelegate {
+                if delegate.responds(to: delegateAction) {
+                    gestureRecognizer.addTarget(delegate, action: delegateAction)
+                } else {
+                    assertionFailure("Please don't set a custom delegate on \(UINavigationController.self).\(#selector(getter: UINavigationController.interactivePopGestureRecognizer)).")
+                    return false
+                }
             }
             return (navigationController?.viewControllers.count ?? 0) > 1
         default:


### PR DESCRIPTION
This change was made for a bug in partial Xcoordinator applications, see #184.