### PR TITLE
Draft: tvOS Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "XCoordinator",
-    platforms: [.iOS(.v9)],
+    platforms: [.iOS(.v9), .tvOS(.v9)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Sources/XCoordinator/InterruptibleTransitionAnimation.swift
+++ b/Sources/XCoordinator/InterruptibleTransitionAnimation.swift
@@ -12,7 +12,7 @@ import UIKit
 /// [UIViewPropertyAnimator](https://developer.apple.com/documentation/uikit/UIViewPropertyAnimator)
 /// APIs introduced in iOS 10.
 ///
-@available(iOS 10.0, *)
+@available(iOS 10.0, tvOS 10.0, *)
 open class InterruptibleTransitionAnimation: InteractiveTransitionAnimation {
 
     // MARK: Stored properties

--- a/Sources/XCoordinator/NavigationAnimationDelegate.swift
+++ b/Sources/XCoordinator/NavigationAnimationDelegate.swift
@@ -132,7 +132,9 @@ extension NavigationAnimationDelegate: UINavigationControllerDelegate {
     ///
     open func navigationController(_ navigationController: UINavigationController,
                                    didShow viewController: UIViewController, animated: Bool) {
+        #if !os(tvOS)
         setupPopGestureRecognizer(for: navigationController)
+        #endif
         presentable?.childTransitionCompleted()
         delegate?.navigationController?(navigationController, didShow: viewController, animated: animated)
     }
@@ -152,6 +154,8 @@ extension NavigationAnimationDelegate: UINavigationControllerDelegate {
         delegate?.navigationController?(navigationController, willShow: viewController, animated: animated)
     }
 }
+
+#if !os(tvOS)
 
 // MARK: - UIGestureRecognizerDelegate
 
@@ -270,6 +274,8 @@ extension NavigationAnimationDelegate: UIGestureRecognizerDelegate {
     }
 
 }
+
+#endif
 
 extension UINavigationController {
     internal var animationDelegate: NavigationAnimationDelegate? {

--- a/Sources/XCoordinator/Router.swift
+++ b/Sources/XCoordinator/Router.swift
@@ -83,6 +83,7 @@ extension Router {
             contextTrigger(route, with: options) { _ in completion?() }
         }
     }
+
 }
 
 extension Router {
@@ -112,6 +113,7 @@ extension Router {
     public func router<R: Route>(for route: R) -> StrongRouter<R>? {
         strongRouter as? StrongRouter<R>
     }
+
 }
 
 #if swift(>=5.5.2)

--- a/Sources/XCoordinator/TabBarAnimationDelegate.swift
+++ b/Sources/XCoordinator/TabBarAnimationDelegate.swift
@@ -102,6 +102,8 @@ extension TabBarAnimationDelegate: UITabBarControllerDelegate {
         delegate?.tabBarController?(tabBarController, shouldSelect: viewController) ?? true
     }
 
+    #if !os(tvOS)
+
     ///
     /// See [UITabBarControllerDelegate](https://developer.apple.com/documentation/uikit/UITabBarControllerDelegate)
     /// for further reference.
@@ -146,6 +148,9 @@ extension TabBarAnimationDelegate: UITabBarControllerDelegate {
                                willEndCustomizing viewControllers: [UIViewController], changed: Bool) {
         delegate?.tabBarController?(tabBarController, willEndCustomizing: viewControllers, changed: changed)
     }
+
+    #endif
+
 }
 
 extension UITabBarController {

--- a/Sources/XCoordinatorCombine/Router+Combine.swift
+++ b/Sources/XCoordinatorCombine/Router+Combine.swift
@@ -16,22 +16,33 @@ public struct PublisherExtension<Base> {
 }
 
 extension Router {
+
     public var publishers: PublisherExtension<Self> {
         .init(base: self)
     }
-}
 
-@available(iOS 13.0, *)
-extension PublisherExtension where Base: Router {
-
-    public func trigger(_ route: Base.RouteType,
-                        with options: TransitionOptions = .init(animated: true)
-        ) -> Future<Void, Never> {
+    @available(iOS 13.0, tvOS 13.0, *)
+    public func triggerPublisher(
+        _ route: RouteType,
+        with options: TransitionOptions = .init(animated: true)
+    ) -> Future<Void, Never> {
         Future { completion in
-            self.base.trigger(route, with: options) {
+            self.trigger(route, with: options) {
                 completion(.success(()))
             }
         }
+    }
+
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension PublisherExtension where Base: Router {
+
+    public func trigger(
+        _ route: Base.RouteType,
+        with options: TransitionOptions = .init(animated: true)
+    ) -> Future<Void, Never> {
+        base.triggerPublisher(route, with: options)
     }
 
 }


### PR DESCRIPTION
Planned for 2.1

Changelog:
- Enable the tvOS platform for Swift Package Manager, Cocoapods and Carthage
- Add compiler directives to hide non-tvOS compliant code when building for tvOS
