### PR TITLE
remove redundant conformance constraint

### DIFF
--- a/Sources/XCoordinator/Coordinator.swift
+++ b/Sources/XCoordinator/Coordinator.swift
@@ -72,7 +72,7 @@ extension Coordinator {
     }
 }
 
-extension Coordinator where Self: Presentable & AnyObject {
+extension Coordinator where Self: AnyObject {
 
     ///
     /// Creates a WeakRouter object from the given router to abstract from concrete implementations

--- a/Sources/XCoordinator/Router.swift
+++ b/Sources/XCoordinator/Router.swift
@@ -85,7 +85,7 @@ extension Router {
     }
 }
 
-extension Router where Self: Presentable {
+extension Router {
 
     // MARK: Computed properties
 


### PR DESCRIPTION
`Coordinator`/`Router` is already conformed to Presentable, there's no need to declare redundantly.