### PR TITLE
Expose coordinator's children in protocol

### DIFF
--- a/Sources/XCoordinator/AnyCoordinator.swift
+++ b/Sources/XCoordinator/AnyCoordinator.swift
@@ -34,6 +34,7 @@ public class AnyCoordinator<RouteType: Route, TransitionType: TransitionProtocol
     private let _prepareTransition: (RouteType) -> TransitionType
     private let _viewController: () -> UIViewController?
     private let _rootViewController: () -> TransitionType.RootViewController
+    private let _children: () -> [Presentable]
     private let _presented: (Presentable?) -> Void
     private let _setRoot: (UIWindow) -> Void
     private let _addChild: (Presentable) -> Void
@@ -55,6 +56,7 @@ public class AnyCoordinator<RouteType: Route, TransitionType: TransitionProtocol
         self._prepareTransition = coordinator.prepareTransition
         self._viewController = { coordinator.viewController }
         self._rootViewController = { coordinator.rootViewController }
+        self._children = { coordinator.children }
         self._presented = coordinator.presented
         self._setRoot = coordinator.setRoot
         self._addChild = coordinator.addChild
@@ -71,6 +73,10 @@ public class AnyCoordinator<RouteType: Route, TransitionType: TransitionProtocol
 
     public var viewController: UIViewController! {
         _viewController()
+    }
+    
+    public var children: [Presentable] {
+        _children()
     }
 
     // MARK: Methods

--- a/Sources/XCoordinator/BaseCoordinator.swift
+++ b/Sources/XCoordinator/BaseCoordinator.swift
@@ -27,11 +27,6 @@ open class BaseCoordinator<RouteType: Route, TransitionType: TransitionProtocol>
     private var removeParentChildren: () -> Void = {}
     private var gestureRecognizerTargets = [GestureRecognizerTarget]()
     
-    ///
-    /// The child coordinators that are currently in the view hierarchy.
-    /// When performing a transition, children are automatically added and removed from this array
-    /// depending on whether they are in the view hierarchy.
-    ///
     public private(set) var children = [Presentable]()
 
     // MARK: Computed properties

--- a/Sources/XCoordinator/Coordinator.swift
+++ b/Sources/XCoordinator/Coordinator.swift
@@ -23,6 +23,13 @@ public typealias ContextPresentationHandler = (TransitionContext) -> Void
 public protocol Coordinator: Router, TransitionPerformer {
 
     ///
+    /// The child coordinators that are currently in the view hierarchy.
+    /// When performing a transition, children are automatically added and removed from this array
+    /// depending on whether they are in the view hierarchy.
+    ///
+    var children: [Presentable] { get }
+    
+    ///
     /// This method prepares transitions for routes.
     /// It especially decides, which transitions are performed for the triggered routes.
     ///


### PR DESCRIPTION
As Coordinator itself has methods `addChild` and `removeChild`, it can be useful to have access to `children` from any Coordinator. Previously it was only accessible from BaseCoordinator, which is a base class for any other coordinators.